### PR TITLE
Create pandoc submodule

### DIFF
--- a/manubot/cite/tests/test_cite_command.py
+++ b/manubot/cite/tests/test_cite_command.py
@@ -5,8 +5,8 @@ import subprocess
 
 import pytest
 
-from manubot.cite.cite_command import (
-    _get_pandoc_info,
+from manubot.pandoc.util import (
+    get_pandoc_info,
 )
 
 
@@ -70,7 +70,7 @@ def test_cite_command_render_stdout(args, expected):
     The output is sensitive to the version of Pandoc used, so rather than fail when
     the system's pandoc is outdated, the test is skipped. 
     """
-    pandoc_version = _get_pandoc_info()['pandoc version']
+    pandoc_version = get_pandoc_info()['pandoc version']
     for output in 'markdown', 'html', 'jats':
         if output in args and pandoc_version < (2, 5):
             pytest.skip(f"Test {output} output assumes pandoc >= 2.5")

--- a/manubot/pandoc/util.py
+++ b/manubot/pandoc/util.py
@@ -1,0 +1,45 @@
+import logging
+import shutil
+import subprocess
+import functools
+
+
+@functools.lru_cache()
+def get_pandoc_info():
+    """
+    Return path and version information for the system's pandoc and
+    pandoc-citeproc commands. When Pandoc is installed,
+    the output will look like:
+    {
+        'pandoc': True,
+        'pandoc path': '/PATH_TO_EXECUTABLES/pandoc',
+        'pandoc version': (2, 5),
+        'pandoc-citeproc': True,
+        'pandoc-citeproc path': '/PATH_TO_EXECUTABLES/pandoc-citeproc',
+        'pandoc-citeproc version': (0, 15),
+    }
+    If the executables are missing, the output will be like:
+    {
+        'pandoc': False,
+        'pandoc-citeproc': False,
+    }
+    """
+    stats = dict()
+    for command in 'pandoc', 'pandoc-citeproc':
+        path = shutil.which(command)
+        stats[command] = bool(path)
+        if not path:
+            continue
+        version = subprocess.check_output(
+            args=[command, '--version'],
+            universal_newlines=True,
+        )
+        logging.debug(version)
+        version, *discard = version.splitlines()
+        discard, version = version.strip().split()
+        from packaging.version import parse as parse_version
+        version = parse_version(version).release
+        stats[f'{command} version'] = version
+        stats[f'{command} path'] = path
+    logging.info('\n'.join(f'{k}: {v}' for k, v in stats.items()))
+    return stats

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setuptools.setup(
         'jinja2',
         'jsonref',
         'jsonschema',
+        'packaging',
         'pandas',
         'pybase62',
         'pyyaml',


### PR DESCRIPTION
Move get_pandoc_info to manubot.pandoc.util.

Use packaging.version.parse to parse pandoc version string

This PR takes parts from https://github.com/manubot/manubot/pull/99, hoping to break that PR into more manageable chunks.

The `manubot.pandoc` module will be helpful for https://github.com/manubot/manubot/issues/100 / https://github.com/manubot/manubot/pull/99.
