### PR TITLE
setup.py: use package_data not MANIFEST to include data files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include manubot/cite/*.lua

--- a/manubot/cite/tests/test_zotero.py
+++ b/manubot/cite/tests/test_zotero.py
@@ -24,7 +24,7 @@ def test_web_query():
     zotero_data = web_query(url)
     assert isinstance(zotero_data, list)
     assert len(zotero_data) == 1
-    assert zotero_data[0]['title'] == "Meet the Robin Hood of Science"
+    assert zotero_data[0]['title'].startswith("Meet the Robin Hood of Science")
 
 
 def test_export_as_csl():

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,6 @@ setuptools.setup(
         ],
     },
 
-    # Include package data files from MANIFEST.in
-    include_package_data=True,
+    # Include package data files
+    #include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -76,5 +76,7 @@ setuptools.setup(
     },
 
     # Include package data files
-    #include_package_data=True,
+    package_data={
+        'manubot': ['cite/*.lua'],
+    },
 )


### PR DESCRIPTION
In https://github.com/manubot/manubot/pull/51, we could not get `package_data` in `setup.py` to work on Windows. We reported the issue in https://github.com/pypa/setuptools/issues/1459 and switched to using `MANIFEST.in`. The downside of MANIFEST is that it creates an extra file in the root directory of the repository for a rather obscure technical purpose.

In https://github.com/pypa/setuptools/issues/1459#issuecomment-493506713, @aschmied hypothesized `package_data` did not work for us because we passed a string rather than a list. This PR switches back to the `package_data` with the correct syntax.