### PR TITLE
test_remove_jsonschema_errors() forced to use utf-8

### DIFF
--- a/manubot/cite/tests/test_citeproc.py
+++ b/manubot/cite/tests/test_citeproc.py
@@ -14,12 +14,17 @@ csl_instances = [
     x.name for x in directory.glob('csl-json/*-csl')
 ]
 
+
+def load_json(path):
+    return json.loads(path.read_text(encoding='utf-8-sig'))
+
+    
 def test_json_is_readable_on_windows_in_different_oem_encoding():
     name = 'crossref-deep-review-csl'
     path = directory / 'csl-json' / name / 'raw.json'
-    content = path.read_text(encoding='utf-8')
+    content = path.read_text(encoding='utf-8-sig')
     assert content
-    json1 = json.load(path.open('r', encoding='utf-8'))
+    json1 = load_json(path)
     assert json1
     
 
@@ -38,10 +43,8 @@ def test_remove_jsonschema_errors(name):
     pruned.json as that also relies on remove_jsonschema_errors for pruning.
     """    
     data_dir = directory / 'csl-json' / name 
-    def load_json(filename):
-        return json.load((data_dir / filename).open('r', encoding='utf-8'))
-    raw = load_json('raw.json')
-    expected = load_json('pruned.json')
+    raw = load_json(data_dir / 'raw.json')
+    expected = load_json(data_dir / 'pruned.json')
     pruned = remove_jsonschema_errors(raw)
     assert pruned == expected
 

--- a/manubot/cite/tests/test_citeproc.py
+++ b/manubot/cite/tests/test_citeproc.py
@@ -14,6 +14,14 @@ csl_instances = [
     x.name for x in directory.glob('csl-json/*-csl')
 ]
 
+def test_json_is_readable_on_windows_in_different_oem_encoding():
+    name = 'crossref-deep-review-csl'
+    path = directory / 'csl-json' / name / 'raw.json'
+    content = path.read_text(encoding='utf-8')
+    assert content
+    json1 = json.load(path.open('r', encoding='utf-8'))
+    assert json1
+    
 
 @pytest.mark.parametrize('name', csl_instances)
 def test_remove_jsonschema_errors(name):
@@ -28,10 +36,12 @@ def test_remove_jsonschema_errors(name):
     To create a new test case, derive pruned.json from raw.json, by manually
     deleting any invalid fields. Do not use `manubot cite` to directly generate
     pruned.json as that also relies on remove_jsonschema_errors for pruning.
-    """
-    data_dir = directory / 'csl-json' / name
-    raw = json.loads(data_dir.joinpath('raw.json').read_text())
-    expected = json.loads(data_dir.joinpath('pruned.json').read_text())
+    """    
+    data_dir = directory / 'csl-json' / name 
+    def load_json(filename):
+        return json.load((data_dir / filename).open('r', encoding='utf-8'))
+    raw = load_json('raw.json')
+    expected = load_json('pruned.json')
     pruned = remove_jsonschema_errors(raw)
     assert pruned == expected
 

--- a/manubot/cite/tests/test_citeproc.py
+++ b/manubot/cite/tests/test_citeproc.py
@@ -41,8 +41,8 @@ def test_remove_jsonschema_errors(name):
     To create a new test case, derive pruned.json from raw.json, by manually
     deleting any invalid fields. Do not use `manubot cite` to directly generate
     pruned.json as that also relies on remove_jsonschema_errors for pruning.
-    """    
-    data_dir = directory / 'csl-json' / name 
+    """
+    data_dir = directory / 'csl-json' / name
     raw = load_json(data_dir / 'raw.json')
     expected = load_json(data_dir / 'pruned.json')
     pruned = remove_jsonschema_errors(raw)

--- a/manubot/pandoc/tests/test_bibliography.py
+++ b/manubot/pandoc/tests/test_bibliography.py
@@ -43,7 +43,7 @@ def test_load_bibliography_from_text(path):
     """
     https://zbib.org/c7f95cdef6d6409c92ffde24d519435d
     """
-    text = path.read_text(encoding='utf-8')
+    text = path.read_text(encoding='utf-8-sig')
     input_format = path.suffix[1:]
     csl_json = load_bibliography(text=text, input_format=input_format)
     assert len(csl_json) == 2

--- a/manubot/pandoc/tests/test_bibliography.py
+++ b/manubot/pandoc/tests/test_bibliography.py
@@ -43,7 +43,7 @@ def test_load_bibliography_from_text(path):
     """
     https://zbib.org/c7f95cdef6d6409c92ffde24d519435d
     """
-    text = path.read_text()
+    text = path.read_text(encoding='utf-8')
     input_format = path.suffix[1:]
     csl_json = load_bibliography(text=text, input_format=input_format)
     assert len(csl_json) == 2


### PR DESCRIPTION
The change is needed to make test suite to run on non-latin OEM encoding on Windows.