### PR TITLE
Relax repo tests for #140

### DIFF
--- a/manubot/process/tests/test_ci.py
+++ b/manubot/process/tests/test_ci.py
@@ -8,21 +8,44 @@ from ..ci import (
     get_continuous_integration_parameters,
 )
 
+@pytest.fixture
+def info():
+    return get_continuous_integration_parameters()
 
-@pytest.mark.skipif('TRAVIS' not in os.environ, reason='tests environment variables set by Travis builds only')
-def test_get_continuous_integration_parameters_travis():
-    info = get_continuous_integration_parameters()
+
+# TODO: test generic properties of `info` distionary, eg list of keys
+# TODO: make class for get_continuous_integration_parameters
+
+@pytest.mark.skipif('CI' not in os.environ)
+def test_get_continuous_integration_parameters_generic(info):
     assert info is not None
-    assert info['provider'] == 'travis'
-    assert info['repo_slug'] == 'manubot/manubot'
-    assert info['repo_owner'] == 'manubot'
-    assert info['repo_name'] == 'manubot'
+    # assume fork repo name unchanged
+    assert info['repo_slug'].endswith('manubot') 
+    assert info['repo_name'] == 'manubot' 
+    # commis are not empty
     assert info['commit']
     assert info['triggering_commit']
+
+
+# TODO: need similar test for APPVEYOR, what is the slug constant name?
+#       may embed in this test  
+@pytest.mark.skipif('TRAVIS' not in os.environ 
+                     or os.environ['TRAVIS_REPO_SLUG'] != 'manubot/manubot',
+                     reason='this test runs only for ')
+def test_get_continuous_integration_parameters_on_master_repo_on_travis(info):
+    assert info['repo_slug'] == 'manubot/manubot'
+    assert info['repo_owner'] == 'manubot'
+
+@pytest.mark.skipif('TRAVIS' not in os.environ, reason='tests environment variables set by Travis builds only')
+def test_get_continuous_integration_parameters_travis(info):
+    assert info is not None
+    assert info['provider'] == 'travis'
     assert info['build_url'].startswith('https://travis-ci.com/manubot/manubot/builds/')
     assert info['job_url'].startswith('https://travis-ci.com/manubot/manubot/jobs/')
+    
+    # TODO: must be separate test - it depends on owner name
     # test add_manuscript_urls_to_ci_params
-    info_updated = add_manuscript_urls_to_ci_params(info)
+    info_updated = add_manuscript_urls_to_ci_params(info)    
     assert info is info_updated
     assert re.fullmatch(
         pattern=r"https://manubot\.github\.io/manubot/v/[0-9a-f]{40}/",
@@ -31,18 +54,14 @@ def test_get_continuous_integration_parameters_travis():
 
 
 @pytest.mark.skipif('APPVEYOR' not in os.environ, reason='tests environment variables set by AppVeyor builds only')
-def test_get_continuous_integration_parameters_appveyor():
-    info = get_continuous_integration_parameters()
+def test_get_continuous_integration_parameters_appveyor(info):
     assert info is not None
     assert info['provider'] == 'appveyor'
-    assert info['provider_account'] == 'manubot'
-    assert info['repo_slug'] == 'manubot/manubot'
-    assert info['repo_owner'] == 'manubot'
-    assert info['repo_name'] == 'manubot'
-    assert info['commit']
-    assert info['triggering_commit']
+    assert info['provider_account'] == 'manubot' # FIXME
     assert info['build_url'].startswith('https://ci.appveyor.com/project/manubot/manubot/builds/')
     assert info['job_url'].startswith('https://ci.appveyor.com/project/manubot/manubot/build/job/')
+    
+    # TODO: must be separate test - it depends on owner name
     # test add_manuscript_urls_to_ci_params
     info_updated = add_manuscript_urls_to_ci_params(info)
     assert info is info_updated

--- a/manubot/process/tests/test_ci.py
+++ b/manubot/process/tests/test_ci.py
@@ -29,19 +29,22 @@ class Test_get_continuous_integration_parameters():
         assert info['repo_name'] == 'manubot'
         assert info['repo_slug'].endswith('manubot')
 
-    def test_repo_slug(self, info):
+    @pytest.mark.skipif('TRAVIS' not in os.environ,
+                        reason="Test parameters are specific to Travis")    
+    def test_repo_slug_on_travis(self, info):
+        # TRAVIS_REPO_SLUG: The slug (in form: owner_name/repo_name) of the repository 
+        # currently being built. https://docs.travis-ci.com/user/environment-variables/
+        assert info['repo_slug'] == os.environ['TRAVIS_REPO_SLUG']
+        
+
+    @pytest.mark.skipif('APPVEYOR' not in os.environ,
+                        reason="Test parameters are specific to APPVEYOR")    
+    def test_repo_slug_on_travis(self, info):
         # APPVEYOR_PROJECT_NAME - project name
         # APPVEYOR_PROJECT_SLUG - project slug (as seen in project details URL)
         # https://www.appveyor.com/docs/environment-variables/
-        #
-        # TRAVIS_REPO_SLUG: The slug (in form: owner_name/repo_name) of the repository currently being built.
-        # https://docs.travis-ci.com/user/environment-variables/
-        if 'TRAVIS' in os.environ:
-            assert info['repo_slug'] == os.environ['TRAVIS_REPO_SLUG']
-        elif 'APPVEYOR' in os.environ:
-            assert info['repo_slug'] == os.environ['APPVEYOR_PROJECT_SLUG']
-        else:
-            assert False
+        assert info['repo_slug'] == os.environ['APPVEYOR_PROJECT_SLUG']
+
 
     def test_commits_are_not_empty(self, info):
         assert info['commit']

--- a/manubot/process/tests/test_ci.py
+++ b/manubot/process/tests/test_ci.py
@@ -39,7 +39,7 @@ class Test_get_continuous_integration_parameters():
 
     @pytest.mark.skipif('APPVEYOR' not in os.environ,
                         reason="Test parameters are specific to APPVEYOR")    
-    def test_repo_slug_on_travis(self, info):
+    def test_repo_slug_on_appveyor(self, info):
         # APPVEYOR_PROJECT_NAME - project name
         # APPVEYOR_PROJECT_SLUG - project slug (as seen in project details URL)
         # APPVEYOR_REPO_NAME - repository name in format owner-name/repo-name
@@ -86,7 +86,7 @@ class Test_add_manuscript_urls_to_ci_params:
         )
 
     @pytest.mark.skipif('APPVEYOR' not in os.environ
-                        or os.environ['APPVEYOR_PROJECT_SLUG'] != 'manubot/manubot',
+                        or os.environ['APPVEYOR_REPO_NAME'] != 'manubot/manubot',
                         reason="This test is specific to Appveyor")
     def test_on_appveyor(self, info):
         info_updated = add_manuscript_urls_to_ci_params(info)

--- a/manubot/process/tests/test_ci.py
+++ b/manubot/process/tests/test_ci.py
@@ -24,7 +24,7 @@ class Test_get_continuous_integration_parameters():
 
     def test_repo_name(self, info):
         """
-        We assume repo name stays the same in repo forks.
+        We assume 'manubot' repo name stays the same in repo forks.
         """
         assert info['repo_name'] == 'manubot'
         assert info['repo_slug'].endswith('manubot')

--- a/manubot/process/tests/test_ci.py
+++ b/manubot/process/tests/test_ci.py
@@ -16,7 +16,7 @@ def info():
 
 @pytest.mark.skipif(
     'CI' not in os.environ,
-    reason='We are not on Travis or Appveyor.')
+    reason='These tests do not apply outside continious integration system (CI)')
 class Test_get_continuous_integration_parameters():
 
     def test_not_empty(self, info):
@@ -45,7 +45,8 @@ class Test_get_continuous_integration_parameters():
         # https://www.appveyor.com/docs/environment-variables/
         assert info['repo_slug'] == os.environ['APPVEYOR_PROJECT_SLUG']
 
-
+    @pytest.mark.skipif('TRAVIS' not in os.environ or 'APPVEYOR' not in os.environ,
+                        reason="Behaviour not guaranteed outside Travis or Appveyor CI"")
     def test_commits_are_not_empty(self, info):
         assert info['commit']
         assert info['triggering_commit']

--- a/manubot/process/tests/test_ci.py
+++ b/manubot/process/tests/test_ci.py
@@ -42,6 +42,8 @@ class Test_get_continuous_integration_parameters():
     def test_repo_slug_on_appveyor(self, info):
         # APPVEYOR_PROJECT_NAME - project name
         # APPVEYOR_PROJECT_SLUG - project slug (as seen in project details URL)
+        # Note: APPVEYOR_PROJECT_SLUG not he same value as on Travis ('manubot/manubot')
+        #       this is just ('manubot')
         # APPVEYOR_REPO_NAME - repository name in format owner-name/repo-name
         # https://www.appveyor.com/docs/environment-variables/
         assert info['repo_slug'] == os.environ['APPVEYOR_REPO_NAME']

--- a/manubot/process/tests/test_ci.py
+++ b/manubot/process/tests/test_ci.py
@@ -46,7 +46,7 @@ class Test_get_continuous_integration_parameters():
         assert info['repo_slug'] == os.environ['APPVEYOR_PROJECT_SLUG']
 
     @pytest.mark.skipif('TRAVIS' not in os.environ or 'APPVEYOR' not in os.environ,
-                        reason="Behaviour not guaranteed outside Travis or Appveyor CI"")
+                        reason="Behaviour not guaranteed outside Travis or Appveyor CI")
     def test_commits_are_not_empty(self, info):
         assert info['commit']
         assert info['triggering_commit']

--- a/manubot/process/tests/test_ci.py
+++ b/manubot/process/tests/test_ci.py
@@ -42,8 +42,9 @@ class Test_get_continuous_integration_parameters():
     def test_repo_slug_on_travis(self, info):
         # APPVEYOR_PROJECT_NAME - project name
         # APPVEYOR_PROJECT_SLUG - project slug (as seen in project details URL)
+        # APPVEYOR_REPO_NAME - repository name in format owner-name/repo-name
         # https://www.appveyor.com/docs/environment-variables/
-        assert info['repo_slug'] == os.environ['APPVEYOR_PROJECT_SLUG']
+        assert info['repo_slug'] == os.environ['APPVEYOR_REPO_NAME']
 
     @pytest.mark.skipif('TRAVIS' not in os.environ or 'APPVEYOR' not in os.environ,
                         reason="Behaviour not guaranteed outside Travis or Appveyor CI")


### PR DESCRIPTION
Grouped tests into several methods, excluding head-to-head checks for repo slug in most of them. 

Several tests run if repo slug is "manubot/manubot". 

Expected behavior: none of online tests is skipped in master repo. 

This test suit passes on a fork.