### PR TITLE
Generate docs and deploy to gh-pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Auto-generated documentation
+/docs
+
 # Python
 __pycache__/
 *.egg-info/

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ install:
   - python setup.py sdist bdist_wheel
 script:
   - pytest --verbose --color=yes
+  # temporary workaround for portray "Module not found" error https://git.io/JeR9C
+  - export PYTHONPATH=.
   - portray as_html --overwrite --output_dir=docs
 deploy:
   - provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - python setup.py sdist bdist_wheel
 script:
   - pytest
-  - portray as_html --output-dir=docs
+  - portray as_html --overwrite --output_dir=docs
 deploy:
   - provider: pypi
     user: __token__

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,21 @@ install:
   - python setup.py sdist bdist_wheel
 script:
   - pytest
+  - portray as_html --output-dir=docs
 deploy:
-  provider: pypi
-  user: __token__
-  password: $PYPI_PASSWORD
-  on:
-    python: '3.6'
-    repo: manubot/manubot
-    tags: true
-  distributions: sdist bdist_wheel
+  - provider: pypi
+    user: __token__
+    password: $PYPI_PASSWORD
+    on:
+      python: '3.6'
+      repo: manubot/manubot
+      tags: true
+    distributions: sdist bdist_wheel
+  - provider: script
+    script: bash ci/deploy-docs.sh
+    skip_cleanup: true
+    on:
+      python: "3.7"
+      repo: manubot/manubot
+      branch: master
+      condition: $TRAVIS_EVENT_TYPE = "push"

--- a/ci/deploy-docs.sh
+++ b/ci/deploy-docs.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+## deploy-docs.sh: run during a Travis CI build to deploy docs directory to the gh-pages branch on GitHub.
+## References
+## - https://github.com/hetio/xswap/blob/ffbb933d1731c2ce4e4e24f00a9a909b53ddf75c/ci/deploy.sh
+## - https://github.com/manubot/rootstock/blob/6859ada7a28a72cd0ed728e085955f23fadc2b9a/ci/deploy.sh
+## - https://github.com/wp-cli/wp-cli/issues/3798
+## - https://github.com/manubot/catalog/blob/fd0ef6a999cca38890023eb65f19d1b87e96e83c/deploy.sh#L1-L45
+
+# Set options for extra caution & debugging
+set -o errexit \
+    -o nounset \
+    -o pipefail
+
+# Decrypt and add SSH key
+eval "$(ssh-agent -s)"
+(
+  set +o xtrace  # disable xtrace in subshell for private key operations
+  base64 --decode <<< "$GITHUB_PRIVATE_DEPLOY_KEY" | ssh-add -
+)
+
+# Configure git
+git config --global push.default simple
+git config --global user.name "Travis CI"
+git config --global user.email "deploy@travis-ci.com"
+git checkout "$TRAVIS_BRANCH"
+git remote set-url origin "git@github.com:$TRAVIS_REPO_SLUG.git"
+
+# Fetch and create gh-pages branch
+# Travis does a shallow and single branch git clone
+git remote set-branches --add origin gh-pages
+git fetch origin gh-pages:gh-pages
+
+commit_message="\
+Generate docs on $(date --iso --utc)
+[skip ci]
+
+built by $TRAVIS_JOB_WEB_URL
+based on https://github.com/$TRAVIS_REPO_SLUG/commit/$TRAVIS_COMMIT
+"
+# echo >&2 "$commit_message"
+
+ghp-import \
+  --push --no-jekyll \
+  --message="$commit_message" \
+  docs

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ version = pattern.search(text).group(1)
 readme_path = directory.joinpath('README.md')
 long_description = readme_path.read_text(encoding='utf-8-sig')
 
-# extra depedencies with an "all" option
+# extra dependencies with an "all" option
 extras_require = {
     'webpage': [
         'opentimestamps-client',
@@ -36,6 +36,7 @@ setuptools.setup(
     url='https://github.com/manubot/manubot',
     project_urls={
         'Source': 'https://github.com/manubot/manubot',
+        'Documentation': 'https://manubot.github.io/manubot',
         'Tracker': 'https://github.com/manubot/manubot/issues',
         'Homepage': 'https://manubot.org',
         'Publication': 'https://greenelab.github.io/meta-review/',

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,8 @@ extras_require = {
         'opentimestamps-client',
     ],
     'test': [
+        'ghp-import',
+        'portray',
         'pytest',
     ],
 }


### PR DESCRIPTION
Closes https://github.com/manubot/manubot/issues/117

After merge, docs should be regenerated for each commit and deployed to gh-pages. Uses https://github.com/timothycrosley/portray