### PR TITLE
Migrate csl_item_set_standard_id to CSL_Item class

### DIFF
--- a/manubot/cite/citekey.py
+++ b/manubot/cite/citekey.py
@@ -274,7 +274,6 @@ def citekey_to_csl_item(citekey, prune=True):
     Generate a CSL Item (Python dictionary) for the input citekey.
     """
     from manubot.cite.csl_item import CSL_Item
-    from manubot.cite.citeproc import append_to_csl_item_note
     from manubot import __version__ as manubot_version
 
     citekey == standardize_citekey(citekey, warn_if_changed=True)
@@ -291,7 +290,8 @@ def citekey_to_csl_item(citekey, prune=True):
     note_dict = {
         'standard_id': citekey,
     }
-    append_to_csl_item_note(csl_item, note_text, note_dict)
+    csl_item.note_append_text(note_text)
+    csl_item.note_append_dict(note_dict)
 
     short_citekey = shorten_citekey(citekey)
     csl_item.set_id(short_citekey)

--- a/manubot/cite/citeproc.py
+++ b/manubot/cite/citeproc.py
@@ -9,60 +9,6 @@ Citation Style Language (CSL) styles.
 import copy
 import functools
 import logging
-import re
-
-
-def append_to_csl_item_note(csl_item, text='', dictionary={}):
-    """
-    Add information to the note field of a CSL Item.
-    In addition to accepting arbitrary text, the note field can be used to encode
-    additional values not defined by the CSL JSON schema, as per
-    https://github.com/Juris-M/citeproc-js-docs/blob/93d7991d42b4a96b74b7281f38e168e365847e40/csl-json/markup.rst#cheater-syntax-for-odd-fields
-    Use dictionary to specify variable-value pairs.
-    """
-    if not isinstance(csl_item, dict):
-        raise ValueError(
-            f'append_to_csl_item_note: csl_item must be a dict but was of type {type(csl_item)}')
-    if not isinstance(dictionary, dict):
-        raise ValueError(
-            f'append_to_csl_item_note: dictionary must be a dict but was of type {type(dictionary)}')
-    if not isinstance(text, str):
-        raise ValueError(
-            f'append_to_csl_item_note: text must be a str but was of type {type(text)}')
-    note = str(csl_item.get('note', ''))
-    if text:
-        if note and not note.endswith('\n'):
-            note += '\n'
-        note += text
-    for key, value in dictionary.items():
-        if not re.fullmatch(r'[A-Z]+|[-_a-z]+', key):
-            logging.warning(
-                f'append_to_csl_item_note: skipping adding "{key}" because it does not conform to the variable_name syntax as per https://git.io/fjTzW.')
-            continue
-        if '\n' in value:
-            logging.warning(
-                f'append_to_csl_item_note: skipping adding "{key}" because the value contains a newline: "{value}"')
-            continue
-        if note and not note.endswith('\n'):
-            note += '\n'
-        note += f'{key}: {value}'
-    if note:
-        csl_item['note'] = note
-    return csl_item
-
-
-def parse_csl_item_note(note):
-    """
-    Return the dictionary of key-value pairs encoded in a CSL JSON note.
-    Extracts both forms (line-entry and braced-entry) of key-value pairs from "cheater syntax"
-    https://github.com/Juris-M/citeproc-js-docs/blob/93d7991d42b4a96b74b7281f38e168e365847e40/csl-json/markup.rst#cheater-syntax-for-odd-fields
-    """
-    note = str(note)
-    line_matches = re.findall(
-        r'^(?P<key>[A-Z]+|[-_a-z]+): *(?P<value>.+?) *$', note, re.MULTILINE)
-    braced_matches = re.findall(
-        r'{:(?P<key>[A-Z]+|[-_a-z]+): *(?P<value>.+?) *}', note)
-    return dict(line_matches + braced_matches)
 
 
 @functools.lru_cache()

--- a/manubot/cite/csl_item.py
+++ b/manubot/cite/csl_item.py
@@ -191,16 +191,19 @@ class CSL_Item(dict):
         Note that the Manubot software generally refers to the "id" of a CSL Item as a citekey.
         However, in this context, we use "id" rather than "citekey" for consistency with CSL's "id" field.
         """
+        original_id = self.get('id')
         self.infer_id()
-        original_id = self['id']
-        prefixed_id = infer_citekey_prefix(original_id)
-        assert is_valid_citekey(prefixed_id, allow_raw=True)
-        standard_id = standardize_citekey(prefixed_id, warn_if_changed=False)
+        original_standard_id = infer_citekey_prefix(original_id)
+        assert is_valid_citekey(original_standard_id, allow_raw=True)
+        standard_id = standardize_citekey(original_standard_id, warn_if_changed=False)
         add_to_note = {}
         note_dict = self.note_dict
-        if original_id != standard_id:
+        if original_id and original_id != standard_id:
             if original_id != note_dict.get('original_id'):
                 add_to_note['original_id'] = original_id
+        if original_standard_id and original_standard_id != standard_id:
+            if original_standard_id != note_dict.get('original_standard_id'):
+                add_to_note['original_standard_id'] = original_standard_id
         if standard_id != note_dict.get('standard_id'):
             add_to_note['standard_id'] = standard_id
         self.append_to_note(dictionary=add_to_note)

--- a/manubot/cite/csl_item.py
+++ b/manubot/cite/csl_item.py
@@ -145,64 +145,70 @@ class CSL_Item(dict):
             self.validate_against_schema()
         return self
 
+    @property
+    def note_dict(self) -> dict:
+        """
+        Assigning to this dict will not update self["note"].
+        """
+        from .citeproc import parse_csl_item_note
+        note = self.get('note', '')
+        return parse_csl_item_note(note)
+
+    def append_to_note(self, text='', dictionary={}):
+        from .citeproc import append_to_csl_item_note
+        append_to_csl_item_note(self, text='', dictionary={})
+        return self
+
+    def infer_id(self):
+        """
+        Detect and set a non-null/empty for "id" or else raise a ValueError.
+        """
+        if self.get('standard_citation'):
+            # "standard_citation" field is set with a non-null/empty value
+            self.set_id(self.pop('standard_citation'))
+        elif self.note_dict.get('standard_id'):
+            # "standard_id" note field is set with a non-null/empty value
+            self.set_id(self.note_dict['standard_id'])
+        if not self.get('id'):
+            # "id" field does not exist or its value is None or empty
+            raise ValueError(
+                'infer_id could not detect a field with a citation / standard_citation. '
+                'Consider setting the CSL Item "id" field.')
+        return self
+
+    def standardize_id(self):
+        """
+        Extract the standard_id (standard citation key) for a csl_item and modify the csl_item in-place to set its "id" field.
+        The standard_id is extracted from a "standard_citation" field, the "note" field, or the "id" field.
+        Uses the infer_citekey_prefix function to set the prefix.
+        For example, if the extracted standard_id does not begin with a supported prefix (e.g. "doi:", "pmid:"
+        or "raw:"), the citation is assumed to be raw and given a "raw:" prefix.
+        The extracted citation is checked for validity and standardized, after which it is the final "standard_id".
+
+        Regarding csl_item modification, the csl_item "id" field is set to the standard_citation and the note field
+        is created or updated with key-value pairs for standard_id and original_id.
+
+        Note that the Manubot software generally refers to the "id" of a CSL Item as a citekey.
+        However, in this context, we use "id" rather than "citekey" for consistency with CSL's "id" field.
+        """
+        self.infer_id()
+        original_id = self['id']
+        prefixed_id = infer_citekey_prefix(original_id)
+        assert is_valid_citekey(prefixed_id, allow_raw=True)
+        standard_id = standardize_citekey(prefixed_id, warn_if_changed=False)
+        add_to_note = {}
+        note_dict = self.note_dict
+        if original_id != standard_id:
+            if original_id != note_dict.get('original_id'):
+                add_to_note['original_id'] = original_id
+        if standard_id != note_dict.get('standard_id'):
+            add_to_note['standard_id'] = standard_id
+        self.append_to_note(dictionary=add_to_note)
+        self.set_id(standard_id)
+        return self
+
 
 def assert_csl_item_type(x):
     if not isinstance(x, CSL_Item):
         raise TypeError(
             f'Expected CSL_Item object, got {type(x)}')
-
-
-def csl_item_set_standard_id(csl_item):
-    """
-    Extract the standard_id (standard citation key) for a csl_item and modify the csl_item in-place to set its "id" field.
-    The standard_id is extracted from a "standard_citation" field, the "note" field, or the "id" field.
-    If extracting the citation from the "id" field, uses the infer_citekey_prefix function to set the prefix.
-    For example, if the extracted standard_id does not begin with a supported prefix (e.g. "doi:", "pmid:"
-    or "raw:"), the citation is assumed to be raw and given a "raw:" prefix. The extracted citation
-    (referred to as "original_standard_id") is checked for validity and standardized, after which it is
-    the final "standard_id".
-
-    Regarding csl_item modification, the csl_item "id" field is set to the standard_citation and the note field
-    is created or updated with key-value pairs for standard_id, original_standard_id, and original_id.
-
-    Note that the Manubot software generally refers to the "id" of a CSL Item as a citekey.
-    However, in this context, we use "id" rather than "citekey" for consistency with CSL's "id" field.
-    """
-    if not isinstance(csl_item, dict):
-        raise ValueError(
-            "csl_item must be a CSL Data Item represented as a Python dictionary")
-
-    from manubot.cite.citeproc import (
-        append_to_csl_item_note,
-        parse_csl_item_note,
-    )
-    note_dict = parse_csl_item_note(csl_item.get('note', ''))
-
-    original_id = None
-    original_standard_id = None
-    if 'id' in csl_item:
-        original_id = csl_item['id']
-        original_standard_id = infer_citekey_prefix(original_id)
-    if 'standard_id' in note_dict:
-        original_standard_id = note_dict['standard_id']
-    if 'standard_citation' in csl_item:
-        original_standard_id = csl_item.pop('standard_citation')
-    if original_standard_id is None:
-        raise ValueError(
-            'csl_item_set_standard_id could not detect a field with a citation / standard_citation. '
-            'Consider setting the CSL Item "id" field.')
-    assert is_valid_citekey(original_standard_id, allow_raw=True)
-    standard_id = standardize_citekey(
-        original_standard_id, warn_if_changed=False)
-    add_to_note = {}
-    if original_id and original_id != standard_id:
-        if original_id != note_dict.get('original_id'):
-            add_to_note['original_id'] = original_id
-    if original_standard_id and original_standard_id != standard_id:
-        if original_standard_id != note_dict.get('original_standard_id'):
-            add_to_note['original_standard_id'] = original_standard_id
-    if standard_id != note_dict.get('standard_id'):
-        add_to_note['standard_id'] = standard_id
-    append_to_csl_item_note(csl_item, dictionary=add_to_note)
-    csl_item['id'] = standard_id
-    return csl_item

--- a/manubot/cite/csl_item.py
+++ b/manubot/cite/csl_item.py
@@ -156,7 +156,7 @@ class CSL_Item(dict):
 
     def append_to_note(self, text='', dictionary={}):
         from .citeproc import append_to_csl_item_note
-        append_to_csl_item_note(self, text='', dictionary={})
+        append_to_csl_item_note(self, text=text, dictionary=dictionary)
         return self
 
     def infer_id(self):

--- a/manubot/cite/csl_item.py
+++ b/manubot/cite/csl_item.py
@@ -158,6 +158,7 @@ class CSL_Item(dict):
         if text:
             self['note'] = text
         else:
+            # if text is None or an empty string, remove the "note" field
             self.pop('note', None)
 
     @property

--- a/manubot/cite/csl_item.py
+++ b/manubot/cite/csl_item.py
@@ -50,7 +50,6 @@ class CSL_Item(dict):
 
     # The ideas for CSL_Item methods come from the following parts of code:
     #  - [ ] citekey_to_csl_item(citekey, prune=True)
-    #  - [ ] append_to_csl_item_note
     # The methods in CSL_Item class provide primitives to reconstruct
     # fucntions above.
 
@@ -245,7 +244,7 @@ class CSL_Item(dict):
                 add_to_note['original_standard_id'] = original_standard_id
         if standard_id != note_dict.get('standard_id'):
             add_to_note['standard_id'] = standard_id
-        self.append_to_note(dictionary=add_to_note)
+        self.note_append_dict(dictionary=add_to_note)
         self.set_id(standard_id)
         return self
 

--- a/manubot/cite/csl_item.py
+++ b/manubot/cite/csl_item.py
@@ -151,7 +151,7 @@ class CSL_Item(dict):
         Return the value of the "note" field as a string.
         If "note" key is not set, return empty string.
         """
-        return str(self.get('note', ''))
+        return str(self.get('note') or '')
 
     @note.setter
     def note(self, text: str):
@@ -177,6 +177,9 @@ class CSL_Item(dict):
         return dict(line_matches + braced_matches)
 
     def note_append_text(self, text: str):
+        """
+        Append text to the note field of a CSL Item.
+        """
         if not text:
             return
         note = self.note
@@ -186,6 +189,11 @@ class CSL_Item(dict):
         self.note = note
 
     def note_append_dict(self, dictionary: dict):
+        """
+        Append key-value pairs specified by `dictionary` to the note field of a CSL Item.
+        Uses the the [CSL JSON "cheater syntax"](https://github.com/Juris-M/citeproc-js-docs/blob/93d7991d42b4a96b74b7281f38e168e365847e40/csl-json/markup.rst#cheater-syntax-for-odd-fields)
+        to encode additional values not defined by the CSL JSON schema.
+        """
         for key, value in dictionary.items():
             if not re.fullmatch(r'[A-Z]+|[-_a-z]+', key):
                 logging.warning(

--- a/manubot/cite/csl_item.py
+++ b/manubot/cite/csl_item.py
@@ -177,6 +177,8 @@ class CSL_Item(dict):
         return dict(line_matches + braced_matches)
 
     def note_append_text(self, text: str):
+        if not text:
+            return
         note = self.note
         if note and not note.endswith('\n'):
             note += '\n'

--- a/manubot/cite/tests/test_citeproc.py
+++ b/manubot/cite/tests/test_citeproc.py
@@ -4,8 +4,6 @@ import pathlib
 import pytest
 
 from manubot.cite.citeproc import (
-    append_to_csl_item_note,
-    parse_csl_item_note,
     remove_jsonschema_errors,
 )
 

--- a/manubot/cite/tests/test_citeproc.py
+++ b/manubot/cite/tests/test_citeproc.py
@@ -47,35 +47,3 @@ def test_remove_jsonschema_errors(name):
     expected = load_json(data_dir / 'pruned.json')
     pruned = remove_jsonschema_errors(raw)
     assert pruned == expected
-
-
-@pytest.mark.parametrize(['input_note', 'text', 'dictionary', 'expected_note'], [
-    ('preexisting note', '', {}, 'preexisting note'),
-    ('preexisting note', '', {'key': 'the value'}, 'preexisting note\nkey: the value'),
-    ('', '', {'KEYOKAY': 'the value'}, 'KEYOKAY: the value'),
-    ('preexisting note', '', {'KEY-NOT-OKAY': 'the value'}, 'preexisting note'),
-    ('', '', {'standard_citation': 'doi:10.7554/elife.32822'}, 'standard_citation: doi:10.7554/elife.32822'),
-    ('This CSL Item was produced using Manubot.', '', {'standard_citation': 'doi:10.7554/elife.32822'}, 'This CSL Item was produced using Manubot.\nstandard_citation: doi:10.7554/elife.32822'),
-])
-def test_append_to_csl_item_note(input_note, text, dictionary, expected_note):
-    csl_item = {
-        'id': 'test_csl_item',
-        'type': 'entry',
-        'note': input_note,
-    }
-    append_to_csl_item_note(csl_item, text, dictionary)
-    output_note = csl_item['note']
-    assert output_note == expected_note
-
-
-@pytest.mark.parametrize(['note', 'dictionary'], [
-    ('This is a note\nkey_one: value\nKEYTWO: value 2 ', {'key_one': 'value', 'KEYTWO': 'value 2'}),
-    ('BAD_KEY: good value\ngood-key: good value', {'good-key': 'good value'}),
-    ('This is a note {:key_one: value} {:KEYTWO: value 2 } ', {'key_one': 'value', 'KEYTWO': 'value 2'}),
-    ('{:BAD_KEY: good value}\n{:good-key: good value}', {'good-key': 'good value'}),
-    ('Mixed line-entry and braced-entry syntax\nGOODKEY: good value\n{:good-key: good value}', {'GOODKEY': 'good value', 'good-key': 'good value'}),
-    ('Note without any key-value pairs', {}),
-    ('Other text\nstandard_citation: doi:10/ckcj\nMore other text', {'standard_citation': 'doi:10/ckcj'}),
-])
-def test_parse_csl_item_note(note, dictionary):
-    assert parse_csl_item_note(note) == dictionary

--- a/manubot/cite/tests/test_csl_item.py
+++ b/manubot/cite/tests/test_csl_item.py
@@ -125,7 +125,7 @@ def test_csl_item_standardize_id_note():
 
 
 @pytest.mark.parametrize(['input_note', 'text', 'dictionary', 'expected_note'], [
-    (None, '', {}, ''),
+    ('', '', {}, ''),
     ('preexisting note', '', {}, 'preexisting note'),
     ('preexisting note', '', {'key': 'the value'}, 'preexisting note\nkey: the value'),
     ('', '', {'KEYOKAY': 'the value'}, 'KEYOKAY: the value'),

--- a/manubot/cite/tests/test_csl_item.py
+++ b/manubot/cite/tests/test_csl_item.py
@@ -126,6 +126,7 @@ def test_csl_item_standardize_id_note():
 
 @pytest.mark.parametrize(['input_note', 'text', 'dictionary', 'expected_note'], [
     ('', '', {}, ''),
+    (None, '', {}, ''),
     ('preexisting note', '', {}, 'preexisting note'),
     ('preexisting note', '', {'key': 'the value'}, 'preexisting note\nkey: the value'),
     ('', '', {'KEYOKAY': 'the value'}, 'KEYOKAY: the value'),

--- a/manubot/cite/tests/test_csl_item.py
+++ b/manubot/cite/tests/test_csl_item.py
@@ -119,8 +119,7 @@ def test_csl_item_standardize_id_note():
     })
     csl_item.standardize_id()
     assert csl_item['id'] == 'doi:10.1371/journal.ppat.1006256'
-    from manubot.cite.citeproc import parse_csl_item_note
-    note_dict = parse_csl_item_note(csl_item['note'])
+    note_dict = csl_item.note_dict
     assert note_dict['original_id'] == 'original-id'
     assert note_dict['original_standard_id'] == 'doi:10.1371/journal.PPAT.1006256'
 
@@ -134,7 +133,7 @@ def test_csl_item_standardize_id_note():
     ('', '', {'standard_citation': 'doi:10.7554/elife.32822'}, 'standard_citation: doi:10.7554/elife.32822'),
     ('This CSL Item was produced using Manubot.', '', {'standard_citation': 'doi:10.7554/elife.32822'}, 'This CSL Item was produced using Manubot.\nstandard_citation: doi:10.7554/elife.32822'),
 ])
-def test_append_to_csl_item_note(input_note, text, dictionary, expected_note):
+def test_csl_item_note_append(input_note, text, dictionary, expected_note):
     csl_item = CSL_Item({
         'id': 'test_csl_item',
         'type': 'entry',
@@ -154,6 +153,6 @@ def test_append_to_csl_item_note(input_note, text, dictionary, expected_note):
     ('Note without any key-value pairs', {}),
     ('Other text\nstandard_citation: doi:10/ckcj\nMore other text', {'standard_citation': 'doi:10/ckcj'}),
 ])
-def test_parse_csl_item_note(note, dictionary):
+def test_csl_item_note_dict(note, dictionary):
     csl_item = CSL_Item(note=note)
     assert csl_item.note_dict == dictionary

--- a/manubot/cite/tests/test_csl_item.py
+++ b/manubot/cite/tests/test_csl_item.py
@@ -123,3 +123,37 @@ def test_csl_item_standardize_id_note():
     note_dict = parse_csl_item_note(csl_item['note'])
     assert note_dict['original_id'] == 'original-id'
     assert note_dict['original_standard_id'] == 'doi:10.1371/journal.PPAT.1006256'
+
+
+@pytest.mark.parametrize(['input_note', 'text', 'dictionary', 'expected_note'], [
+    (None, '', {}, ''),
+    ('preexisting note', '', {}, 'preexisting note'),
+    ('preexisting note', '', {'key': 'the value'}, 'preexisting note\nkey: the value'),
+    ('', '', {'KEYOKAY': 'the value'}, 'KEYOKAY: the value'),
+    ('preexisting note', '', {'KEY-NOT-OKAY': 'the value'}, 'preexisting note'),
+    ('', '', {'standard_citation': 'doi:10.7554/elife.32822'}, 'standard_citation: doi:10.7554/elife.32822'),
+    ('This CSL Item was produced using Manubot.', '', {'standard_citation': 'doi:10.7554/elife.32822'}, 'This CSL Item was produced using Manubot.\nstandard_citation: doi:10.7554/elife.32822'),
+])
+def test_append_to_csl_item_note(input_note, text, dictionary, expected_note):
+    csl_item = CSL_Item({
+        'id': 'test_csl_item',
+        'type': 'entry',
+        'note': input_note,
+    })
+    csl_item.note_append_text(text)
+    csl_item.note_append_dict(dictionary)
+    assert csl_item.note == expected_note
+
+
+@pytest.mark.parametrize(['note', 'dictionary'], [
+    ('This is a note\nkey_one: value\nKEYTWO: value 2 ', {'key_one': 'value', 'KEYTWO': 'value 2'}),
+    ('BAD_KEY: good value\ngood-key: good value', {'good-key': 'good value'}),
+    ('This is a note {:key_one: value} {:KEYTWO: value 2 } ', {'key_one': 'value', 'KEYTWO': 'value 2'}),
+    ('{:BAD_KEY: good value}\n{:good-key: good value}', {'good-key': 'good value'}),
+    ('Mixed line-entry and braced-entry syntax\nGOODKEY: good value\n{:good-key: good value}', {'GOODKEY': 'good value', 'good-key': 'good value'}),
+    ('Note without any key-value pairs', {}),
+    ('Other text\nstandard_citation: doi:10/ckcj\nMore other text', {'standard_citation': 'doi:10/ckcj'}),
+])
+def test_parse_csl_item_note(note, dictionary):
+    csl_item = CSL_Item(note=note)
+    assert csl_item.note_dict == dictionary

--- a/manubot/cite/tests/test_csl_item.py
+++ b/manubot/cite/tests/test_csl_item.py
@@ -117,7 +117,7 @@ def test_csl_item_standardize_id_note():
         'type': 'article-journal',
         'note': 'standard_id: doi:10.1371/journal.PPAT.1006256',
     })
-    csl_item.standardize_id
+    csl_item.standardize_id()
     assert csl_item['id'] == 'doi:10.1371/journal.ppat.1006256'
     from manubot.cite.citeproc import parse_csl_item_note
     note_dict = parse_csl_item_note(csl_item['note'])

--- a/manubot/cite/tests/test_csl_item.py
+++ b/manubot/cite/tests/test_csl_item.py
@@ -3,7 +3,6 @@ import copy
 import pytest
 
 from manubot.cite.csl_item import (
-    csl_item_set_standard_id,
     CSL_Item,
     assert_csl_item_type)
 
@@ -93,35 +92,32 @@ def test_assert_csl_item_type_raises_error_on_dict():
         'from_raw_id',
     ]
 )
-def test_csl_item_set_standard_id(csl_item, standard_citation):
-    output = csl_item_set_standard_id(csl_item)
+def test_csl_item_standardize_id(csl_item, standard_citation):
+    csl_item = CSL_Item(csl_item)
+    output = csl_item.standardize_id()
     assert output is csl_item
     assert output['id'] == standard_citation
 
 
-def test_csl_item_set_standard_id_repeated():
-    csl_item = {
-        'id': 'pmid:1',
-        'type': 'article-journal',
-    }
-    # csl_item_0 = copy.deepcopy(csl_item)
-    csl_item_1 = copy.deepcopy(csl_item_set_standard_id(csl_item))
+def test_csl_item_standardize_id_repeated():
+    csl_item = CSL_Item(id='pmid:1', type='article-journal')
+    csl_item_1 = copy.deepcopy(csl_item.standardize_id())
     assert 'standard_citation' not in 'csl_item'
-    csl_item_2 = copy.deepcopy(csl_item_set_standard_id(csl_item))
+    csl_item_2 = copy.deepcopy(csl_item.standardize_id())
     assert csl_item_1 == csl_item_2
 
 
-def test_csl_item_set_standard_id_note():
+def test_csl_item_standardize_id_note():
     """
     Test extracting standard_id from a note and setting additional
     note fields.
     """
-    csl_item = {
+    csl_item = CSL_Item({
         'id': 'original-id',
         'type': 'article-journal',
         'note': 'standard_id: doi:10.1371/journal.PPAT.1006256',
-    }
-    csl_item_set_standard_id(csl_item)
+    })
+    csl_item.standardize_id
     assert csl_item['id'] == 'doi:10.1371/journal.ppat.1006256'
     from manubot.cite.citeproc import parse_csl_item_note
     note_dict = parse_csl_item_note(csl_item['note'])

--- a/manubot/process/bibliography.py
+++ b/manubot/process/bibliography.py
@@ -4,7 +4,6 @@ import pathlib
 
 from manubot import __version__ as manubot_version
 from manubot.cite.citeproc import append_to_csl_item_note
-from manubot.cite.csl_item import csl_item_set_standard_id
 from manubot.cite.citekey import shorten_citekey
 
 
@@ -70,7 +69,7 @@ def load_manual_references(paths=[], extra_csl_items=[]) -> dict:
     manual_refs = dict()
     for csl_item in csl_items:
         try:
-            csl_item_set_standard_id(csl_item)
+            csl_item.standardize_id()
         except Exception:
             csl_item_str = json.dumps(csl_item, indent=2)
             logging.info(f'Skipping csl_item where setting standard_id failed:\n{csl_item_str}', exc_info=True)

--- a/manubot/process/bibliography.py
+++ b/manubot/process/bibliography.py
@@ -3,7 +3,6 @@ import logging
 import pathlib
 
 from manubot import __version__ as manubot_version
-from manubot.cite.citeproc import append_to_csl_item_note
 from manubot.cite.citekey import shorten_citekey
 
 
@@ -59,11 +58,8 @@ def load_manual_references(paths=[], extra_csl_items=[]) -> dict:
             logging.warning(f'process.load_bibliographies is skipping a non-existent path: {path}')
             continue
         for csl_item in load_bibliography(path):
-            append_to_csl_item_note(
-                csl_item,
-                text=f'This CSL JSON Item was loaded by Manubot v{manubot_version} from a manual reference file.',
-                dictionary={'manual_reference_filename': path.name},
-            )
+            csl_item.note_append_text(f'This CSL JSON Item was loaded by Manubot v{manubot_version} from a manual reference file.')
+            csl_item.note_append_dict({'manual_reference_filename': path.name})
             csl_items.append(csl_item)
     csl_items.extend(map(CSL_Item, extra_csl_items))
     manual_refs = dict()


### PR DESCRIPTION
Migrate additional functionality to the CSL_Item class. Specifically, csl_item_set_standard_id is now CSL_Item.starndardize_id. append_to_csl_item_note is now note_append_dict and note_append_text