### PR TITLE
Test on Python 3.8

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,9 +12,6 @@ environment:
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7.x"
       PYTHON_ARCH: "64"
-    - PYTHON: "C:\\Python38-x64"
-      PYTHON_VERSION: "3.8.x"
-      PYTHON_ARCH: "64"
 
 build: off
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,6 +12,9 @@ environment:
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7.x"
       PYTHON_ARCH: "64"
+    - PYTHON: "C:\\Python38-x64"
+      PYTHON_VERSION: "3.8.x"
+      PYTHON_ARCH: "64"
 
 build: off
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
-dist: xenial
+dist: bionic
 sudo: true
 language: python
 python:
   - "3.6"
   - "3.7"
+  - "3.8"
 cache:
   - pip
 before_install:

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,13 @@
 import pytest
 
 
+def pytest_configure(config):
+    # register an additional marker
+    config.addinivalue_line(
+        "markers", "pandoc_version_sensitive: marks tests that require a specific version of pandoc to pass"
+    )
+
+
 def pytest_addoption(parser):
     parser.addoption(
         '--use-requests-cache',

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,8 @@ setuptools.setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 
     packages=setuptools.find_packages(


### PR DESCRIPTION
AppVeyor does not support Python 3.8 yet as per https://github.com/appveyor/ci/issues/3142.