### PR TITLE
Support metadata.thumbnail / variables.thumbnail_url

### DIFF
--- a/manubot/process/tests/test_thumbnail.py
+++ b/manubot/process/tests/test_thumbnail.py
@@ -5,11 +5,20 @@ from ..thumbnail import get_thumbnail_url
 from ..ci import get_continuous_integration_parameters
 
 ci_params = get_continuous_integration_parameters() or {}
-local_only = pytest.mark.skipif(ci_params, reason="skipping on local build since test assumes supported CI behavior")
-ci_only = pytest.mark.skipif(not ci_params, reason="skipping on CI build since test assumes local behavior")
+local_only = pytest.mark.skipif(
+    ci_params, reason="skipping on local build since test assumes supported CI behavior"
+)
+ci_only = pytest.mark.skipif(
+    not ci_params, reason="skipping on CI build since test assumes local behavior"
+)
 
-repo_raw_url_template = f"https://github.com/manubot/manubot/raw/{ci_params.get('triggering_commit', '')}/"
-example_thumbnail_url = repo_raw_url_template + 'manubot/process/tests/manuscripts/example/thumbnail.png'
+repo_raw_url_template = (
+    f"https://github.com/manubot/manubot/raw/{ci_params.get('triggering_commit', '')}/"
+)
+example_thumbnail_url = (
+    repo_raw_url_template + "manubot/process/tests/manuscripts/example/thumbnail.png"
+)
+
 
 @pytest.mark.parametrize(
     ("thumbnail", "expected"),
@@ -18,10 +27,25 @@ example_thumbnail_url = repo_raw_url_template + 'manubot/process/tests/manuscrip
         pytest.param("", None, id="empty-on-local", marks=local_only),
         pytest.param(None, example_thumbnail_url, id="None-on-ci", marks=ci_only),
         pytest.param("", example_thumbnail_url, id="empty-on-ci", marks=ci_only),
-        pytest.param("path/to/thumbnail.png", None, id="local-path-on-local", marks=local_only),
-        pytest.param("path/to/thumbnail.png", repo_raw_url_template + "path/to/thumbnail.png", id="local-path-on-ci", marks=ci_only),
-        pytest.param("http://example.com/thumbnail.png", "http://example.com/thumbnail.png", id="url-http"),
-        pytest.param("https://example.com/thumbnail.png", "https://example.com/thumbnail.png", id="url-https"),
+        pytest.param(
+            "path/to/thumbnail.png", None, id="local-path-on-local", marks=local_only
+        ),
+        pytest.param(
+            "path/to/thumbnail.png",
+            repo_raw_url_template + "path/to/thumbnail.png",
+            id="local-path-on-ci",
+            marks=ci_only,
+        ),
+        pytest.param(
+            "http://example.com/thumbnail.png",
+            "http://example.com/thumbnail.png",
+            id="url-http",
+        ),
+        pytest.param(
+            "https://example.com/thumbnail.png",
+            "https://example.com/thumbnail.png",
+            id="url-https",
+        ),
     ],
 )
 def test_get_thumbnail_url(thumbnail, expected):

--- a/manubot/process/tests/test_thumbnail.py
+++ b/manubot/process/tests/test_thumbnail.py
@@ -13,7 +13,8 @@ ci_only = pytest.mark.skipif(
 )
 
 repo_raw_url_template = (
-    f"https://github.com/manubot/manubot/raw/{ci_params.get('triggering_commit', '')}/"
+    f"https://github.com/{ci_params.get('repo_slug', '')}"
+    f"/raw/{ci_params.get('triggering_commit', '')}/"
 )
 example_thumbnail_url = (
     repo_raw_url_template + "manubot/process/tests/manuscripts/example/thumbnail.png"

--- a/manubot/process/tests/test_thumbnail.py
+++ b/manubot/process/tests/test_thumbnail.py
@@ -2,17 +2,29 @@ import pytest
 
 
 from ..thumbnail import get_thumbnail_url
+from ..ci import get_continuous_integration_parameters
 
+ci_params = get_continuous_integration_parameters() or {}
+local_only = pytest.mark.skipif(ci_params, reason="skipping on local build since test assumes supported CI behavior")
+ci_only = pytest.mark.skipif(not ci_params, reason="skipping on CI build since test assumes local behavior")
+
+repo_raw_url_template = f"https://github.com/manubot/manubot/raw/{ci_params.get('triggering_commit', '')}/"
+example_thumbnail_url = repo_raw_url_template + 'manubot/process/tests/manuscripts/example/thumbnail.png'
 
 @pytest.mark.parametrize(
     ("thumbnail", "expected"),
     [
-        (None, None),
-        ("", None),
-        ("http://example.com/thumbnail.png", "http://example.com/thumbnail.png"),
-        ("https://example.com/thumbnail.png", "https://example.com/thumbnail.png"),
+        pytest.param(None, None, id="None-on-local", marks=local_only),
+        pytest.param("", None, id="empty-on-local", marks=local_only),
+        pytest.param(None, example_thumbnail_url, id="None-on-ci", marks=ci_only),
+        pytest.param("", example_thumbnail_url, id="empty-on-ci", marks=ci_only),
+        pytest.param("path/to/thumbnail.png", None, id="local-path-on-local", marks=local_only),
+        pytest.param("path/to/thumbnail.png", repo_raw_url_template + "path/to/thumbnail.png", id="local-path-on-ci", marks=ci_only),
+        pytest.param("http://example.com/thumbnail.png", "http://example.com/thumbnail.png", id="url-http"),
+        pytest.param("https://example.com/thumbnail.png", "https://example.com/thumbnail.png", id="url-https"),
     ],
 )
 def test_get_thumbnail_url(thumbnail, expected):
+    print(ci_params)
     thumbnail_url = get_thumbnail_url(thumbnail)
-    assert thumbnail_url == expected
+    assert expected == thumbnail_url

--- a/manubot/process/tests/test_thumbnail.py
+++ b/manubot/process/tests/test_thumbnail.py
@@ -50,6 +50,5 @@ example_thumbnail_url = (
     ],
 )
 def test_get_thumbnail_url(thumbnail, expected):
-    print(ci_params)
     thumbnail_url = get_thumbnail_url(thumbnail)
     assert expected == thumbnail_url

--- a/manubot/process/tests/test_thumbnail.py
+++ b/manubot/process/tests/test_thumbnail.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-from ..thumbnail import test_get_thumbnail_url
+from ..thumbnail import get_thumbnail_url
 
 
 @pytest.mark.parametrize(
@@ -14,5 +14,5 @@ from ..thumbnail import test_get_thumbnail_url
     ],
 )
 def test_get_thumbnail_url(thumbnail, expected):
-    thumbnail_url = test_get_thumbnail_url(thumbnail)
+    thumbnail_url = get_thumbnail_url(thumbnail)
     assert thumbnail_url == expected

--- a/manubot/process/thumbnail.py
+++ b/manubot/process/thumbnail.py
@@ -1,0 +1,78 @@
+"""
+Tools for manuscript thumbnial detection and processing.
+"""
+import functools
+import pathlib
+import subprocess
+from urllib.parse import urlparse
+
+# Valid schemes for URL detection
+url_schemes = {"http", "https"}
+
+
+def get_thumbnail_url(thumbnail=None):
+    """
+    Starting with a user-specified `thumbnail` as either a path, URL, or None,
+    return a web-accessible URL with thumbnail. If provided `thumbnail` is a URL,
+    return the URL unmodified. If `thumbnail` is None, search for `thumbnail.png`
+    within the git repository from which this function is executed. If a local path
+    is provided or detected, convert that path to a GitHub raw URL.
+    """
+    if not thumbnail:
+        # thumbnail not provided, so find local path if exists
+        thumbnail = _find_thumbnail_path()
+    elif urlparse(thumbnail).scheme in url_schemes:
+        # provided thumbnail is a URL. Pass it through.
+        return thumbnail
+    return _thumbnail_path_to_url(thumbnail)
+
+
+def _find_thumbnail_path():
+    """
+    If this this function is executed with a working directory that is inside a git repository,
+    return the path to a `thumbnail.png` file located anywhere in that repository.
+    """
+    directory = git_repository_root()
+    if not directory:
+        return None
+    paths = directory.glob("**/thumbnail.png")
+    paths = [path.relative_to(directory) for path in paths]
+    paths = sorted(paths, key=lambda x: (len(x.parents), x))
+    if not paths:
+        return None
+    return paths[0].as_posix()
+
+
+def _thumbnail_path_to_url(path):
+    """
+    Convert a local thumbnail path (string) to a web-accessible URL using the GitHub
+    repository location detected using `get_continuous_integration_parameters`.
+    """
+    if not path:
+        return None
+    from .ci import get_continuous_integration_parameters
+
+    info = get_continuous_integration_parameters()
+    try:
+        url = f"https://github.com/{info['repo_slug']}/raw/{info['triggering_commit']}/{path}"
+    except KeyError:
+        return None
+    return url
+
+
+@functools.lru_cache()
+def git_repository_root():
+    """
+    Return the path to repository root directory or None if indeterminate.
+    """
+    for cmd in (
+        ["git", "rev-parse", "--show-superproject-working-tree"],
+        ["git", "rev-parse", "--show-toplevel"],
+    ):
+        try:
+            path = subprocess.check_output(cmd, universal_newlines=True).rstrip("\r\n")
+            if path:
+                return pathlib.Path(path)
+        except (subprocess.CalledProcessError, OSError):
+            pass
+    return None

--- a/manubot/process/thumbnail.py
+++ b/manubot/process/thumbnail.py
@@ -57,7 +57,7 @@ def _thumbnail_path_to_url(path):
     info = get_continuous_integration_parameters()
     try:
         url = f"https://github.com/{info['repo_slug']}/raw/{info['triggering_commit']}/{path}"
-    except KeyError:
+    except (TypeError, KeyError):
         return None
     return url
 

--- a/manubot/process/thumbnail.py
+++ b/manubot/process/thumbnail.py
@@ -15,8 +15,10 @@ def get_thumbnail_url(thumbnail=None):
     Starting with a user-specified `thumbnail` as either a path, URL, or None,
     return a web-accessible URL with thumbnail. If provided `thumbnail` is a URL,
     return the URL unmodified. If `thumbnail` is None, search for `thumbnail.png`
-    within the git repository from which this function is executed. If a local path
-    is provided or detected, convert that path to a GitHub raw URL.
+    within the git repository from which this function is executed. If `thumbnail`
+    is a local path, it should be relative to root directory of the git repository
+    if is located in. If a local path is provided or detected, convert that path
+    to a GitHub raw URL.
     """
     if not thumbnail:
         # thumbnail not provided, so find local path if exists

--- a/manubot/process/thumbnail.py
+++ b/manubot/process/thumbnail.py
@@ -6,19 +6,19 @@ import pathlib
 import subprocess
 from urllib.parse import urlparse
 
-# Valid schemes for URL detection
+"""Valid schemes for URL detection"""
 url_schemes = {"http", "https"}
 
 
 def get_thumbnail_url(thumbnail=None):
     """
     Starting with a user-specified `thumbnail` as either a path, URL, or None,
-    return a web-accessible URL with thumbnail. If provided `thumbnail` is a URL,
-    return the URL unmodified. If `thumbnail` is None, search for `thumbnail.png`
+    return an absolute URL pointing to the thumbnail image. If the provided `thumbnail`
+    is a URL, return this URL unmodified. If `thumbnail` is None, search for `thumbnail.png`
     within the git repository from which this function is executed. If `thumbnail`
-    is a local path, it should be relative to root directory of the git repository
-    if is located in. If a local path is provided or detected, convert that path
-    to a GitHub raw URL.
+    is a local path, the path should be relative to root directory of the git repository
+    it is located in. If a local path is provided or detected,
+    it is converted to a GitHub raw URL.
     """
     if not thumbnail:
         # thumbnail not provided, so find local path if exists
@@ -32,7 +32,8 @@ def get_thumbnail_url(thumbnail=None):
 def _find_thumbnail_path():
     """
     If this this function is executed with a working directory that is inside a git repository,
-    return the path to a `thumbnail.png` file located anywhere in that repository.
+    return the path to a `thumbnail.png` file located anywhere in that repository. Otherwise,
+    return `None`.
     """
     directory = git_repository_root()
     if not directory:
@@ -47,7 +48,7 @@ def _find_thumbnail_path():
 
 def _thumbnail_path_to_url(path):
     """
-    Convert a local thumbnail path (string) to a web-accessible URL using the GitHub
+    Convert a local thumbnail path (string) to an absolute URL using the GitHub
     repository location detected using `get_continuous_integration_parameters`.
     """
     if not path:
@@ -65,7 +66,7 @@ def _thumbnail_path_to_url(path):
 @functools.lru_cache()
 def git_repository_root():
     """
-    Return the path to repository root directory or None if indeterminate.
+    Return the path to repository root directory or `None` if indeterminate.
     """
     for cmd in (
         ["git", "rev-parse", "--show-superproject-working-tree"],

--- a/manubot/process/util.py
+++ b/manubot/process/util.py
@@ -17,6 +17,7 @@ from manubot.process.ci import (
     add_manuscript_urls_to_ci_params,
     get_continuous_integration_parameters,
 )
+from manubot.process.thumbnail import get_thumbnail_url
 from manubot.process.manuscript import (
     datetime_now,
     get_citekeys,
@@ -206,6 +207,11 @@ def get_metadata_and_variables(args):
     ci_params = get_continuous_integration_parameters()
     if ci_params:
         variables["ci_source"] = add_manuscript_urls_to_ci_params(ci_params)
+
+    # Add thumbnail URL if present
+    thumbnail_url = get_thumbnail_url(metadata.pop("thumbnail", None))
+    if thumbnail_url:
+        variables["thumbnail_url"] = thumbnail_url
 
     # Update variables with user-provided variables here
     user_variables = read_jsons(args.template_variables_path)

--- a/manubot/tests/test_thumbnail.py
+++ b/manubot/tests/test_thumbnail.py
@@ -1,0 +1,18 @@
+import pytest
+
+
+from ..thumbnail import test_get_thumbnail_url
+
+
+@pytest.mark.parametrize(
+    ("thumbnail", "expected"),
+    [
+        (None, None),
+        ("", None),
+        ("http://example.com/thumbnail.png", "http://example.com/thumbnail.png"),
+        ("https://example.com/thumbnail.png", "https://example.com/thumbnail.png"),
+    ],
+)
+def test_get_thumbnail_url(thumbnail, expected):
+    thumbnail_url = test_get_thumbnail_url(thumbnail)
+    assert thumbnail_url == expected


### PR DESCRIPTION
Refs https://github.com/manubot/rootstock/issues/267

This commit adds a `thumbnail_url` field to `output/variables.json`. The thumbnail can be specified by a repo-relative path, an existing URL, or automatically detected if `thumbnail.png` exists.

git_repository_root is derived from _git_project_root in https://github.com/pdoc3/pdoc/commit/b47e916d78821dd9918b83f4a23b859b9cc473c5.