### PR TITLE
header-includes-template.html: don't encapsulate in code block

### DIFF
--- a/manubot/process/header-includes-template.html
+++ b/manubot/process/header-includes-template.html
@@ -1,7 +1,6 @@
-```html {=html}
 <!--
-Manubot generated metadata rendered from header-includes-template.md.
-Suggest improvements at https://github.com/manubot/manubot/blob/master/manubot/process/header-includes-template.md
+Manubot generated metadata rendered from header-includes-template.html.
+Suggest improvements at https://github.com/manubot/manubot/blob/master/manubot/process/header-includes-template.html
 -->
 <meta name="dc.format" content="text/html" />
 {% if pandoc.title is defined -%}
@@ -74,4 +73,3 @@ Suggest improvements at https://github.com/manubot/manubot/blob/master/manubot/p
 <link rel="mask-icon" href="https://manubot.org/safari-pinned-tab.svg" color="#ad1457" />
 <meta name="theme-color" content="#ad1457" />
 <!-- end Manubot generated metadata -->
-```

--- a/manubot/process/metadata.py
+++ b/manubot/process/metadata.py
@@ -11,11 +11,11 @@ from urllib.parse import urljoin
 
 def get_header_includes(variables: dict) -> str:
     """
-    Render `header-includes-template.md` using information from `variables`.
+    Render `header-includes-template.html` using information from `variables`.
     """
     from .util import template_with_jinja2
 
-    path = pathlib.Path(__file__).parent.joinpath("header-includes-template.md")
+    path = pathlib.Path(__file__).parent.joinpath("header-includes-template.html")
     try:
         template = path.read_text(encoding="utf-8-sig")
         return template_with_jinja2(template, variables)

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setuptools.setup(
     package_data={
         "manubot": [
             "cite/*.lua",
-            "process/header-includes-template.md",
+            "process/header-includes-template.html",
             "webpage/redirect-template.html",
         ]
     },


### PR DESCRIPTION
Previously pandoc was producing the following from our `header-includes` that was wrapped in a code block:

```html
  <code>html {=html} &lt;!-- Manubot generated metadata rendered from header-includes-template.md. Suggest improvements at https://github.com/manubot/manubot/blob/master/manubot/process/header-includes-template.md --&gt; &lt;meta name="dc.format" content="text/html" /&gt; &lt;meta name="dc.title" content="Manuscript Title" /&gt; &lt;meta name="citation_title" content="Manuscript Title" /&gt; &lt;meta property="og:title" content="Manuscript Title" /&gt; &lt;meta property="twitter:title" content="Manuscript Title" /&gt; &lt;meta name="dc.date" content="2019-11-19" /&gt; &lt;meta name="citation_publication_date" content="2019-11-19" /&gt; &lt;meta name="dc.language" content="en-US" /&gt; &lt;meta name="citation_language" content="en-US" /&gt; &lt;meta name="dc.relation.ispartof" content="Manubot" /&gt; &lt;meta name="dc.publisher" content="Manubot" /&gt; &lt;meta name="citation_journal_title" content="Manubot" /&gt; &lt;meta name="citation_technical_report_institution" content="Manubot" /&gt; &lt;meta name="citation_author" content="John Doe" /&gt; &lt;meta name="citation_author_institution" content="Department of Something, University of Whatever" /&gt; &lt;meta name="citation_author_orcid" content="XXXX-XXXX-XXXX-XXXX" /&gt; &lt;meta name="twitter:creator" content="@johndoe" /&gt; &lt;meta name="citation_author" content="Jane Roe" /&gt; &lt;meta name="citation_author_institution" content="Department of Something, University of Whatever" /&gt; &lt;meta name="citation_author_institution" content="Department of Whatever, University of Something" /&gt; &lt;meta name="citation_author_orcid" content="XXXX-XXXX-XXXX-XXXX" /&gt; &lt;link rel="canonical" href="https://manubot.github.io/rootstock/" /&gt; &lt;meta property="og:url" content="https://manubot.github.io/rootstock/" /&gt; &lt;meta property="twitter:url" content="https://manubot.github.io/rootstock/" /&gt; &lt;meta name="citation_fulltext_html_url" content="https://manubot.github.io/rootstock/" /&gt; &lt;meta name="citation_pdf_url" content="https://manubot.github.io/rootstock/manuscript.pdf" /&gt; &lt;link rel="alternate" type="application/pdf" href="https://manubot.github.io/rootstock/manuscript.pdf" /&gt; &lt;link rel="alternate" type="text/html" href="https://manubot.github.io/rootstock/v/f0d5c22febd72223923c32c942af5c96bbeba05a/" /&gt; &lt;meta name="manubot_html_url_versioned" content="https://manubot.github.io/rootstock/v/f0d5c22febd72223923c32c942af5c96bbeba05a/" /&gt; &lt;meta name="manubot_pdf_url_versioned" content="https://manubot.github.io/rootstock/v/f0d5c22febd72223923c32c942af5c96bbeba05a/manuscript.pdf" /&gt; &lt;meta property="og:type" content="article" /&gt; &lt;meta property="twitter:card" content="summary_large_image" /&gt; &lt;link rel="icon" type="image/png" sizes="192x192" href="https://manubot.org/favicon-192x192.png" /&gt; &lt;link rel="mask-icon" href="https://manubot.org/safari-pinned-tab.svg" color="#ad1457" /&gt; &lt;meta name="theme-color" content="#ad1457" /&gt; &lt;!-- end Manubot generated metadata --&gt;</code>
  
  <!-- pandoc-eqnos: equation style -->
  <style>
    .eqnos { display: inline-block; position: relative; width: 100%; }
    .eqnos br { display: none; }
    .eqnos-number { position: absolute; right: 0em; top: 50%; line-height: 0; }
  </style>
</head>
<body>
<header id="title-block-header">
<h1 class="title">Manuscript Title</h1>
</header>
<p><small><em> This manuscript (<a href="">permalink</a>) was automatically generated from <a href="https://github.com/manubot/rootstock/tree/f0d5c22febd72223923c32c942af5c96bbeba05a">manubot/rootstock@f0d5c22</a> on . </em></small></p>
```