### PR TITLE
url_to_citekey: convert from URL to citekey

### DIFF
--- a/manubot/cite/citekey.py
+++ b/manubot/cite/citekey.py
@@ -323,6 +323,10 @@ def url_to_citekey(url):
         # DOI URLs
         doi = unquote(parsed_url.path.lstrip("/"))
         return f"doi:{doi}"
+    if parsed_url.hostname.split(".")[-2:] == ["biorxiv", "org"]:
+        # bioRxiv URL to DOI
+        (biorxiv_id,) = re.findall(r"/([0-9]{6})", parsed_url.path)
+        return f"doi:10.1101/{biorxiv_id}"
     is_ncbi_url = parsed_url.hostname.endswith("ncbi.nlm.nih.gov")
     if is_ncbi_url and parsed_url.path.startswith("/pubmed/"):
         # PubMed URLs

--- a/manubot/cite/citekey.py
+++ b/manubot/cite/citekey.py
@@ -86,6 +86,9 @@ def standardize_citekey(citekey, warn_if_changed=False):
 
 
 regexes = {
+    "arxiv": re.compile(
+        r"([0-9]{4}\.[0-9]{4,5}|[a-z\-]+(\.[A-Z]{2})?/[0-9]{7})(v[0-9]+)?"
+    ),
     "pmid": re.compile(r"[1-9][0-9]{0,7}"),
     "pmcid": re.compile(r"PMC[0-9]+"),
     "doi": re.compile(r"10\.[0-9]{4,9}/\S+"),
@@ -100,6 +103,11 @@ def inspect_citekey(citekey):
     string describing the issue is returned. Otherwise returns None.
     """
     source, identifier = citekey.split(":", 1)
+
+    if source == "arxiv":
+        # https://arxiv.org/help/arxiv_identifier
+        if not regexes["arxiv"].fullmatch(identifier):
+            return "arXiv identifiers must conform to syntax described at https://arxiv.org/help/arxiv_identifier."
 
     if source == "pmid":
         # https://www.nlm.nih.gov/bsd/mms/medlineelements.html#pmid
@@ -314,39 +322,60 @@ def infer_citekey_prefix(citekey):
 def url_to_citekey(url):
     """
     Convert a HTTP(s) URL into a citekey.
-    For supproted sources, convert from url citekey to an alternative source like doi.
+    For supported sources, convert from url citekey to an alternative source like doi.
+    If citekeys fail inspection, revert alternative sources to URLs.
     """
     from urllib.parse import urlparse, unquote
 
+    citekey = None
     parsed_url = urlparse(url)
     if parsed_url.hostname.split(".")[-2:] == ["doi", "org"]:
         # DOI URLs
         doi = unquote(parsed_url.path.lstrip("/"))
-        return f"doi:{doi}"
+        citekey = f"doi:{doi}"
     if parsed_url.hostname.split(".")[-2:] == ["biorxiv", "org"]:
         # bioRxiv URL to DOI. See https://git.io/Je9Hq
-        (biorxiv_id,) = re.findall(r"/([0-9]{6,})", parsed_url.path)
-        return f"doi:10.1101/{biorxiv_id}"
+        match = re.search(
+            r"/(?P<biorxiv_id>([0-9]{4}\.[0-9]{2}\.[0-9]{2}\.)?[0-9]{6,})",
+            parsed_url.path,
+        )
+        if match:
+            citekey = f"doi:10.1101/{match.group('biorxiv_id')}"
     is_ncbi_url = parsed_url.hostname.endswith("ncbi.nlm.nih.gov")
     if is_ncbi_url and parsed_url.path.startswith("/pubmed/"):
         # PubMed URLs
-        pmid = parsed_url.path.split("/")[2]
-        return f"pmid:{pmid}"
+        try:
+            pmid = parsed_url.path.split("/")[2]
+            citekey = f"pmid:{pmid}"
+        except IndexError:
+            pass
     if is_ncbi_url and parsed_url.path.startswith("/pmc/"):
         # PubMed Central URLs
-        pmcid = parsed_url.path.split("/")[3]
-        return f"pmcid:{pmcid}"
+        try:
+            pmcid = parsed_url.path.split("/")[3]
+            citekey = f"pmcid:{pmcid}"
+        except IndexError:
+            pass
     if parsed_url.hostname.split(".")[-2:] == [
         "wikidata",
         "org",
     ] and parsed_url.path.startswith("/wiki/"):
         # Wikidata URLs
-        wikidata_id = parsed_url.path.split("/")[2]
-        return f"wikidata:{wikidata_id}"
+        try:
+            wikidata_id = parsed_url.path.split("/")[2]
+            citekey = f"wikidata:{wikidata_id}"
+        except IndexError:
+            pass
+
     if parsed_url.hostname.split(".")[-2:] == ["arxiv", "org"]:
         # arXiv identifiers. See https://arxiv.org/help/arxiv_identifier
-        arxiv_id = parsed_url.path.split("/", maxsplit=2)[2]
-        if arxiv_id.endswith(".pdf"):
-            arxiv_id = arxiv_id[:-4]
-        return f"arxiv:{arxiv_id}"
-    return f"url:{url}"
+        try:
+            arxiv_id = parsed_url.path.split("/", maxsplit=2)[2]
+            if arxiv_id.endswith(".pdf"):
+                arxiv_id = arxiv_id[:-4]
+            citekey = f"arxiv:{arxiv_id}"
+        except IndexError:
+            pass
+    if citekey is None or inspect_citekey(citekey) is not None:
+        citekey = f"url:{url}"
+    return citekey

--- a/manubot/cite/citekey.py
+++ b/manubot/cite/citekey.py
@@ -366,7 +366,6 @@ def url_to_citekey(url):
             citekey = f"wikidata:{wikidata_id}"
         except IndexError:
             pass
-
     if parsed_url.hostname.split(".")[-2:] == ["arxiv", "org"]:
         # arXiv identifiers. See https://arxiv.org/help/arxiv_identifier
         try:

--- a/manubot/cite/citekey.py
+++ b/manubot/cite/citekey.py
@@ -324,8 +324,8 @@ def url_to_citekey(url):
         doi = unquote(parsed_url.path.lstrip("/"))
         return f"doi:{doi}"
     if parsed_url.hostname.split(".")[-2:] == ["biorxiv", "org"]:
-        # bioRxiv URL to DOI
-        (biorxiv_id,) = re.findall(r"/([0-9]{6})", parsed_url.path)
+        # bioRxiv URL to DOI. See https://git.io/Je9Hq
+        (biorxiv_id,) = re.findall(r"/([0-9]{6,})", parsed_url.path)
         return f"doi:10.1101/{biorxiv_id}"
     is_ncbi_url = parsed_url.hostname.endswith("ncbi.nlm.nih.gov")
     if is_ncbi_url and parsed_url.path.startswith("/pubmed/"):

--- a/manubot/cite/tests/test_citekey.py
+++ b/manubot/cite/tests/test_citekey.py
@@ -131,6 +131,7 @@ def test_infer_citekey_prefix(citation, expect):
         ),
         ("http://dx.doi.org/10.7554/eLife.46574", "doi:10.7554/eLife.46574"),
         ("https://doi.org/10/b6vnmd#anchor", "doi:10/b6vnmd"),
+        ("https://www.biorxiv.org/content/10.1101/087619v3", "doi:10.1101/087619"),
         ("https://www.ncbi.nlm.nih.gov/pubmed/31233491", "pmid:31233491"),
         ("https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4304851/", "pmcid:PMC4304851"),
         ("https://www.wikidata.org/wiki/Q50051684", "wikidata:Q50051684"),

--- a/manubot/cite/tests/test_citekey.py
+++ b/manubot/cite/tests/test_citekey.py
@@ -132,6 +132,11 @@ def test_infer_citekey_prefix(citation, expect):
         ("http://dx.doi.org/10.7554/eLife.46574", "doi:10.7554/eLife.46574"),
         ("https://doi.org/10/b6vnmd#anchor", "doi:10/b6vnmd"),
         ("https://www.biorxiv.org/content/10.1101/087619v3", "doi:10.1101/087619"),
+        ("https://www.biorxiv.org/content/10.1101/087619v3.full", "doi:10.1101/087619"),
+        (
+            "https://www.biorxiv.org/content/early/2017/08/31/087619.full.pdf",
+            "doi:10.1101/087619",
+        ),
         ("https://www.ncbi.nlm.nih.gov/pubmed/31233491", "pmid:31233491"),
         ("https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4304851/", "pmcid:PMC4304851"),
         ("https://www.wikidata.org/wiki/Q50051684", "wikidata:Q50051684"),

--- a/manubot/cite/tests/test_citekey.py
+++ b/manubot/cite/tests/test_citekey.py
@@ -66,6 +66,11 @@ def test_shorten_citekey(standard_citekey, expected):
         "pmcid:PMC4304851",
         "pmid:25648772",
         "arxiv:1407.3561",
+        "arxiv:1407.3561v1",
+        "arxiv:math.GT/0309136",
+        "arxiv:math.GT/0309136v1",
+        "arxiv:hep-th/9305059",
+        "arxiv:hep-th/9305059v2",
         "isbn:978-1-339-91988-1",
         "isbn:1-339-91988-5",
         "wikidata:Q1",
@@ -95,6 +100,7 @@ def test_inspect_citekey_passes(citekey):
         ("isbn:1-339-91988-X", "identifier violates the ISBN syntax"),
         ("wikidata:P212", "item IDs must start with 'Q'"),
         ("wikidata:QABCD", "does not conform to the Wikidata regex"),
+        ("arxiv:YYMM.number", "must conform to syntax"),
     ],
 )
 def test_inspect_citekey_fails(citekey, contains):
@@ -125,24 +131,67 @@ def test_infer_citekey_prefix(citation, expect):
 @pytest.mark.parametrize(
     ["url", "citekey"],
     [
+        ("https://www.doi.org/", "url:https://www.doi.org/",),
+        (
+            "https://www.doi.org/factsheets/Identifier_Interoper.html",
+            "url:https://www.doi.org/factsheets/Identifier_Interoper.html",
+        ),
         (
             "https://doi.org/10.1097%2F00004032-200403000-00012",
             "doi:10.1097/00004032-200403000-00012",
         ),
         ("http://dx.doi.org/10.7554/eLife.46574", "doi:10.7554/eLife.46574"),
         ("https://doi.org/10/b6vnmd#anchor", "doi:10/b6vnmd"),
+        # ShortDOI URLs without `10/` prefix not yet supported`
+        ("https://doi.org/b6vnmd", "url:https://doi.org/b6vnmd"),
+        (
+            "https://www.biorxiv.org/about-biorxiv",
+            "url:https://www.biorxiv.org/about-biorxiv",
+        ),
         ("https://www.biorxiv.org/content/10.1101/087619v3", "doi:10.1101/087619"),
         ("https://www.biorxiv.org/content/10.1101/087619v3.full", "doi:10.1101/087619"),
         (
             "https://www.biorxiv.org/content/early/2017/08/31/087619.full.pdf",
             "doi:10.1101/087619",
         ),
+        (
+            "https://www.biorxiv.org/content/10.1101/2019.12.11.872580v1",
+            "doi:10.1101/2019.12.11.872580",
+        ),
+        (
+            "https://www.biorxiv.org/content/10.1101/2019.12.11.872580v1.full.pdf+html",
+            "doi:10.1101/2019.12.11.872580",
+        ),
+        (
+            "https://www.biorxiv.org/content/10.1101/2019.12.11.872580v1.full.pdf",
+            "doi:10.1101/2019.12.11.872580",
+        ),
+        ("https://www.ncbi.nlm.nih.gov", "url:https://www.ncbi.nlm.nih.gov"),
+        (
+            "https://www.ncbi.nlm.nih.gov/pubmed",
+            "url:https://www.ncbi.nlm.nih.gov/pubmed",
+        ),
         ("https://www.ncbi.nlm.nih.gov/pubmed/31233491", "pmid:31233491"),
+        ("https://www.ncbi.nlm.nih.gov/pmc/", "url:https://www.ncbi.nlm.nih.gov/pmc/"),
+        (
+            "https://www.ncbi.nlm.nih.gov/pmc/about/intro/",
+            "url:https://www.ncbi.nlm.nih.gov/pmc/about/intro/",
+        ),
         ("https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4304851/", "pmcid:PMC4304851"),
+        (
+            "https://www.wikidata.org/wiki/Wikidata:Main_Page",
+            "url:https://www.wikidata.org/wiki/Wikidata:Main_Page",
+        ),
         ("https://www.wikidata.org/wiki/Q50051684", "wikidata:Q50051684"),
+        ("https://arxiv.org/", "url:https://arxiv.org/"),
+        (
+            "https://arxiv.org/list/q-fin/recent",
+            "url:https://arxiv.org/list/q-fin/recent",
+        ),
         ("https://arxiv.org/abs/1912.03529v1", "arxiv:1912.03529v1"),
         ("https://arxiv.org/pdf/1912.03529v1.pdf", "arxiv:1912.03529v1"),
         ("https://arxiv.org/ps/1912.03529v1", "arxiv:1912.03529v1"),
+        ("https://arxiv.org/abs/math.GT/0309136", "arxiv:math.GT/0309136"),
         ("https://arxiv.org/abs/hep-th/9305059", "arxiv:hep-th/9305059"),
         ("https://arxiv.org/pdf/hep-th/9305059.pdf", "arxiv:hep-th/9305059"),
     ],

--- a/manubot/cite/tests/test_citekey.py
+++ b/manubot/cite/tests/test_citekey.py
@@ -7,6 +7,7 @@ from manubot.cite.citekey import (
     shorten_citekey,
     infer_citekey_prefix,
     inspect_citekey,
+    url_to_citekey,
 )
 
 
@@ -119,3 +120,26 @@ def test_inspect_citekey_fails(citekey, contains):
 )
 def test_infer_citekey_prefix(citation, expect):
     assert infer_citekey_prefix(citation) == expect
+
+
+@pytest.mark.parametrize(
+    ["url", "citekey"],
+    [
+        (
+            "https://doi.org/10.1097%2F00004032-200403000-00012",
+            "doi:10.1097/00004032-200403000-00012",
+        ),
+        ("http://dx.doi.org/10.7554/eLife.46574", "doi:10.7554/eLife.46574"),
+        ("https://doi.org/10/b6vnmd#anchor", "doi:10/b6vnmd"),
+        ("https://www.ncbi.nlm.nih.gov/pubmed/31233491", "pmid:31233491"),
+        ("https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4304851/", "pmcid:PMC4304851"),
+        ("https://www.wikidata.org/wiki/Q50051684", "wikidata:Q50051684"),
+        ("https://arxiv.org/abs/1912.03529v1", "arxiv:1912.03529v1"),
+        ("https://arxiv.org/pdf/1912.03529v1.pdf", "arxiv:1912.03529v1"),
+        ("https://arxiv.org/ps/1912.03529v1", "arxiv:1912.03529v1"),
+        ("https://arxiv.org/abs/hep-th/9305059", "arxiv:hep-th/9305059"),
+        ("https://arxiv.org/pdf/hep-th/9305059.pdf", "arxiv:hep-th/9305059"),
+    ],
+)
+def test_url_to_citekey(url, citekey):
+    assert url_to_citekey(url) == citekey

--- a/manubot/cite/tests/test_url.py
+++ b/manubot/cite/tests/test_url.py
@@ -1,3 +1,5 @@
+import pytest
+
 from manubot.cite.url import get_url_csl_item_zotero
 
 
@@ -40,6 +42,9 @@ def test_get_url_csl_item_zotero_manubot():
     assert [int(x) for x in csl_item["issued"]["date-parts"][0]] == [2018, 12, 18]
 
 
+@pytest.mark.skip(
+    reason="test intermittently fails as metadata varies between two states"
+)
 def test_get_url_csl_item_zotero_github():
     """
     This command creates two translation-server queries. The first query is


### PR DESCRIPTION
closes https://github.com/manubot/manubot/issues/61

currently, `url_to_citekey` is not used by Manubot, but is a convenience function for users of the package.

todo:

- [x] should we standardize?
- [x] should we handle errors?
- [x] should we test pathological URLs?