### PR TITLE
Configure & enforce flake8 linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+ignore = E203, E266, E501, W503
+max-line-length = 80
+# TODO: refactor to reduce max-complexity to 18
+max-complexity = 19
+select = B,C,E,F,W,T4,B9

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ script:
   # ensure your local version of black matches the version installed on Travis,
   # which will usually be the latest version from https://pypi.org/project/black/
   - black --check --diff .
+  - flake8
   # temporary workaround for portray "Module not found" error https://git.io/JeR9C
   - export PYTHONPATH=.
   - portray as_html --overwrite --output_dir=docs

--- a/README.md
+++ b/README.md
@@ -253,6 +253,9 @@ pytest
 # reformat Python files according to the black style rules (required to pass CI)
 black .
 
+# detect any flake8 linting violations
+flake8
+
 # regenerate the README codeblocks for --help messages
 python manubot/tests/test_readme.py
 

--- a/manubot/cite/arxiv.py
+++ b/manubot/cite/arxiv.py
@@ -1,4 +1,3 @@
-import collections
 import logging
 import re
 import xml.etree.ElementTree

--- a/manubot/cite/wikidata.py
+++ b/manubot/cite/wikidata.py
@@ -10,6 +10,6 @@ def get_wikidata_csl_item(identifier):
     csl_item = get_url_csl_item_zotero(url)
     if "DOI" in csl_item:
         csl_item["DOI"] = csl_item["DOI"].lower()
-    if not "URL" in csl_item:
+    if "URL" not in csl_item:
         csl_item["URL"] = url
     return csl_item

--- a/manubot/tests/test_imports.py
+++ b/manubot/tests/test_imports.py
@@ -6,6 +6,8 @@ def test_imports():
     import manubot.cite.url
     import manubot.process.manuscript
 
+    manubot
+
 
 def assert_instance_type():
     from manubot.cite.citekey import citeproc_retrievers

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ long_description = readme_path.read_text(encoding="utf-8-sig")
 # extra dependencies with an "all" option
 extras_require = {
     "webpage": ["opentimestamps-client"],
-    "test": ["black", "ghp-import", "portray", "pytest"],
+    "dev": ["black", "flake8", "ghp-import", "portray", "pytest"],
 }
 extras_require["all"] = list(
     dict.fromkeys(itertools.chain.from_iterable(extras_require.values()))


### PR DESCRIPTION
black alone is insufficient to catch errors like undefined variables and unused imports. flake8 does this well, but needs some small configuration as to not fight black.

flake8 does not yet support configuration using pyproject.toml.
Use black configuration as template:
https://github.com/psf/black/blob/1ab87a3f67bc80a2e59be2692f2e2f25dd143af7/.flake8

Changed max complexity since refactor complex functions is outside
the scope of this change.

Enable flake8 checking in CI.

setup.py: rename test extra requirements to dev.