### PR TITLE
arxiv metadata: use OAI endpoint for better metadata

### DIFF
--- a/manubot/cite/arxiv.py
+++ b/manubot/cite/arxiv.py
@@ -211,3 +211,12 @@ def get_arxiv_csl_item_oai(arxiv_id):
 
 def remove_newlines(text):
     return re.sub(pattern=r"\n(?!\s)", repl=" ", string=text)
+
+
+def get_arxiv_csl_item_zotero(arxiv_id):
+    """
+    Generate CSL JSON Data for an arXiv ID using Zotero's translation-server.
+    """
+    from manubot.cite.zotero import get_csl_item
+
+    return get_csl_item(f"arxiv:{arxiv_id}")

--- a/manubot/cite/arxiv.py
+++ b/manubot/cite/arxiv.py
@@ -129,7 +129,7 @@ def get_arxiv_csl_item_export_api(arxiv_id):
     if doi:
         csl_item["DOI"] = doi
         journal_ref = entry.findtext(alt_prefix + "journal_ref")
-    csl_item.log_journal_doi(arxiv_id, journal_ref)
+        csl_item.log_journal_doi(arxiv_id, journal_ref)
     return csl_item
 
 
@@ -205,7 +205,7 @@ def get_arxiv_csl_item_oai(arxiv_id):
     if doi:
         csl_item["DOI"] = doi
         journal_ref = arxiv_elem.findtext(f"{ns_arxiv}journal-ref")
-    csl_item.log_journal_doi(arxiv_id, journal_ref)
+        csl_item.log_journal_doi(arxiv_id, journal_ref)
     return csl_item
 
 

--- a/manubot/cite/citekey.py
+++ b/manubot/cite/citekey.py
@@ -87,7 +87,7 @@ def standardize_citekey(citekey, warn_if_changed=False):
 
 regexes = {
     "arxiv": re.compile(
-        r"([0-9]{4}\.[0-9]{4,5}|[a-z\-]+(\.[A-Z]{2})?/[0-9]{7})(v[0-9]+)?"
+        r"([0-9]{4}\.[0-9]{4,5}|[a-z\-]+(\.[A-Z]{2})?/[0-9]{7})(?P<version>v[0-9]+)?"
     ),
     "pmid": re.compile(r"[1-9][0-9]{0,7}"),
     "pmcid": re.compile(r"PMC[0-9]+"),

--- a/manubot/cite/tests/test_arxiv.py
+++ b/manubot/cite/tests/test_arxiv.py
@@ -15,6 +15,8 @@ def test_get_arxiv_csl_item_abstract_whitespace():
     """
     csl_item = get_arxiv_csl_item("1908.00936v2")
     assert csl_item["title"] == "Multi-Scale Learned Iterative Reconstruction"
+    assert csl_item["URL"] == "https://arxiv.org/abs/1908.00936v2"
+    assert csl_item["version"] == "v2"
     abstract = (
         "Model-based learned iterative reconstruction methods have recently been shown to outperform classical reconstruction algorithms. Applicability of these methods to large scale inverse problems is however limited by the available memory for training and extensive training times due to computationally expensive forward models. As a possible solution to these restrictions we propose a multi-scale learned iterative reconstruction scheme that computes iterates on discretisations of increasing resolution. This procedure does not only reduce memory requirements, it also considerably speeds up reconstruction and training times, but most importantly is scalable to large scale inverse problems with non-trivial forward operators, such as those that arise in many 3D tomographic applications. In particular, we propose a hybrid network that combines the multi-scale iterative approach with a particularly expressive network architecture which in combination exhibits excellent scalability in 3D."
         "\n  Applicability of the algorithm is demonstrated for 3D cone beam computed tomography from real measurement data of an organic phantom. Additionally, we examine scalability and reconstruction quality in comparison to established learned reconstruction methods in two dimensions for low dose computed tomography on human phantoms."
@@ -27,4 +29,10 @@ def test_get_arxiv_csl_item_oai():
     https://export.arxiv.org/oai2?verb=GetRecord&identifier=oai:arXiv.org:1912.04616&metadataPrefix=arXiv
     """
     csl_item = get_arxiv_csl_item_oai("1912.04616")
-    assert csl_item["title"] == "OpenBioLink: A resource and benchmarking framework for large-scale biomedical link prediction"
+    assert (
+        csl_item["title"]
+        == "OpenBioLink: A resource and benchmarking framework for large-scale biomedical link prediction"
+    )
+    assert csl_item["URL"] == "https://arxiv.org/abs/1912.04616"
+    assert csl_item.note_dict["license"]
+    assert csl_item["author"][0]["family"] == "Breit"

--- a/manubot/cite/tests/test_arxiv.py
+++ b/manubot/cite/tests/test_arxiv.py
@@ -1,4 +1,4 @@
-from ..arxiv import get_arxiv_csl_item, get_arxiv_csl_item_oai
+from ..arxiv import get_arxiv_csl_item_export_api, get_arxiv_csl_item_oai
 
 
 def test_get_arxiv_csl_item_abstract_whitespace():
@@ -13,7 +13,7 @@ def test_get_arxiv_csl_item_abstract_whitespace():
     When the abstract is formatted for email announcement,
     it will be wrapped to 80 characters.
     """
-    csl_item = get_arxiv_csl_item("1908.00936v2")
+    csl_item = get_arxiv_csl_item_export_api("1908.00936v2")
     assert csl_item["title"] == "Multi-Scale Learned Iterative Reconstruction"
     assert csl_item["URL"] == "https://arxiv.org/abs/1908.00936v2"
     assert csl_item["version"] == "v2"

--- a/manubot/cite/tests/test_arxiv.py
+++ b/manubot/cite/tests/test_arxiv.py
@@ -1,4 +1,4 @@
-from ..arxiv import get_arxiv_csl_item
+from ..arxiv import get_arxiv_csl_item, get_arxiv_csl_item_oai
 
 
 def test_get_arxiv_csl_item_abstract_whitespace():
@@ -20,3 +20,11 @@ def test_get_arxiv_csl_item_abstract_whitespace():
         "\n  Applicability of the algorithm is demonstrated for 3D cone beam computed tomography from real measurement data of an organic phantom. Additionally, we examine scalability and reconstruction quality in comparison to established learned reconstruction methods in two dimensions for low dose computed tomography on human phantoms."
     )
     assert csl_item["abstract"] == abstract
+
+
+def test_get_arxiv_csl_item_oai():
+    """
+    https://export.arxiv.org/oai2?verb=GetRecord&identifier=oai:arXiv.org:1912.04616&metadataPrefix=arXiv
+    """
+    csl_item = get_arxiv_csl_item_oai("1912.04616")
+    assert csl_item["title"] == "OpenBioLink: A resource and benchmarking framework for large-scale biomedical link prediction"

--- a/manubot/cite/tests/test_citekey_api.py
+++ b/manubot/cite/tests/test_citekey_api.py
@@ -56,7 +56,7 @@ def test_citekey_to_csl_item_arxiv():
     assert csl_item["id"] == "ES92tcdg"
     assert csl_item["URL"] == "https://arxiv.org/abs/cond-mat/0703470v2"
     assert csl_item["number"] == "cond-mat/0703470v2"
-    assert csl_item["version"] == "2"
+    assert csl_item["version"] == "v2"
     assert csl_item["type"] == "report"
     assert csl_item["container-title"] == "arXiv"
     assert csl_item["title"] == "Portraits of Complex Networks"


### PR DESCRIPTION
OAI endpoint adds license and author first/last, but cannot do versioned arxiv links