### PR TITLE
yamllint failing YAML files

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ portray as_html --overwrite --output_dir=docs
 manubot process \
   --content-directory=manubot/process/tests/manuscripts/example/content \
   --output-directory=manubot/process/tests/manuscripts/example/output \
-  --log-level=DEBUG
+  --log-level=INFO
 ```
 
 ### Release instructions

--- a/manubot/process/bibliography.py
+++ b/manubot/process/bibliography.py
@@ -4,6 +4,7 @@ import pathlib
 
 from manubot import __version__ as manubot_version
 from manubot.cite.citekey import shorten_citekey
+from manubot.util import read_serialized_data
 
 
 def load_bibliography(path) -> list:
@@ -13,22 +14,13 @@ def load_bibliography(path) -> list:
     parse these files directly. Otherwise, delegate conversion to CSL Items to pandoc-citeproc.
     """
     path = pathlib.Path(path)
-    use_pandoc_citeproc = True
-    try:
-        if path.suffix == ".json":
-            use_pandoc_citeproc = False
-            with path.open(encoding="utf-8-sig") as read_file:
-                csl_items = json.load(read_file)
-        if path.suffix == ".yaml":
-            use_pandoc_citeproc = False
-            import yaml
-
-            with path.open(encoding="utf-8-sig") as read_file:
-                csl_items = yaml.safe_load(read_file)
-    except Exception:
-        logging.exception(f"process.load_bibliography: error parsing {path}.\n")
-        csl_items = []
-    if use_pandoc_citeproc:
+    if path.suffix in {".json", ".yaml"}:
+        try:
+            csl_items = read_serialized_data(path)
+        except Exception:
+            logging.exception(f"process.load_bibliography: error parsing {path}.\n")
+            csl_items = []
+    else:
         from manubot.pandoc.bibliography import (
             load_bibliography as load_bibliography_pandoc,
         )

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ long_description = readme_path.read_text(encoding="utf-8-sig")
 # extra dependencies with an "all" option
 extras_require = {
     "webpage": ["opentimestamps-client"],
-    "dev": ["black", "flake8", "ghp-import", "portray", "pytest"],
+    "dev": ["black", "flake8", "ghp-import", "portray", "pytest", "yamllint"],
 }
 extras_require["all"] = list(
     dict.fromkeys(itertools.chain.from_iterable(extras_require.values()))


### PR DESCRIPTION
Closes #204 

When reading a .yaml file fails, provide yamllint to stderr if possible.