### PR TITLE
DOI metadata: use DataCite Content Negotiation

### DIFF
--- a/manubot/cite/doi.py
+++ b/manubot/cite/doi.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import urllib.parse
 import urllib.request
 
 import requests
@@ -61,12 +62,23 @@ def get_short_doi_url(doi):
         return None
 
 
+"""
+Base URL to use for content negotiation.
+
+Options include:
+
+1. <https://data.crosscite.org> documented at <https://support.datacite.org/docs/datacite-content-resolver>
+2. <https://doi.org/> documented at <https://citation.crosscite.org/docs.html>
+"""
+content_negotiation_url = "https://data.crosscite.org"
+
+
 def get_doi_csl_item_crosscite(doi):
     """
-    Use Content Negotioation (https://crosscite.org/docs.html) to
-    retrieve the CSL Item metadata for a DOI.
+    Use Content Negotioation to retrieve the CSL Item
+    metadata for a DOI.
     """
-    url = "https://doi.org/" + urllib.request.quote(doi)
+    url = urllib.parse.urljoin(content_negotiation_url, urllib.request.quote(doi))
     header = {
         "Accept": "application/vnd.citationstyles.csl+json",
         "User-Agent": get_manubot_user_agent(),

--- a/manubot/cite/tests/test_doi.py
+++ b/manubot/cite/tests/test_doi.py
@@ -52,3 +52,21 @@ def test_get_doi_csl_item():
     csl_item = get_doi_csl_item(doi)
     assert isinstance(csl_item, dict)
     assert csl_item["URL"] == "https://doi.org/gbpvh5"
+
+
+def test_get_doi_crosscite_with_consortium_author():
+    """
+    Make sure the author "GTEx Consortium" is properly encoded
+    using the `author.literal` CSL JSON field.
+
+    References:
+
+    - <https://github.com/manubot/manubot/issues/158>
+    - <https://github.com/crosscite/content-negotiation/issues/92>
+    """
+    doi = "10.1038/ng.3834"
+    csl_item = get_doi_csl_item_crosscite(doi)
+    assert isinstance(csl_item, dict)
+    assert any(
+        author.get("literal") == "GTEx Consortium" for author in csl_item["author"]
+    )


### PR DESCRIPTION
Refs https://github.com/manubot/manubot/issues/158

DataCite's Content Negotiation returns valid CSL JSON even for Crossref DOIs.
https://github.com/crosscite/content-negotiation/issues/92

https://support.datacite.org/docs/datacite-content-resolver
