### PR TITLE
manubot process: require --skip-citations

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Under this setup, you can run the Manubot using:
 
 ```sh
 manubot process \
+  --skip-citations \
   --content-directory=content \
   --output-directory=output
 ```
@@ -96,7 +97,7 @@ See `manubot process --help` for documentation of all command line arguments:
 usage: manubot process [-h] --content-directory CONTENT_DIRECTORY
                        --output-directory OUTPUT_DIRECTORY
                        [--template-variables-path TEMPLATE_VARIABLES_PATH]
-                       [--skip-citations] [--cache-directory CACHE_DIRECTORY]
+                       --skip-citations [--cache-directory CACHE_DIRECTORY]
                        [--clear-requests-cache]
                        [--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
 
@@ -120,8 +121,10 @@ optional arguments:
                         `--template-variables-path=namespace=path_or_url`.
                         Namespaces must match the regex `[a-zA-
                         Z_][a-zA-Z0-9_]*`.
-  --skip-citations      Skip citation and reference processing. Specify when
-                        using the pandoc-manubot-cite filter. If citation-
+  --skip-citations      Skip citation and reference processing. Support for
+                        citation and reference processing has been moved from
+                        `manubot process` to the pandoc-manubot-cite filter.
+                        Therefore this argument is now required. If citation-
                         tags.tsv is found in content, these tags will be
                         inserted in the markdown output using the reference-
                         link syntax for citekey aliases. Appends
@@ -139,11 +142,7 @@ optional arguments:
 
 Manubot has the ability to rely on user-provided reference metadata rather than generating it.
 `manubot process` searches the content directory for files containing manually-provided reference metadata that match the glob `manual-references*.*`.
-If a manual reference filename ends with `.json` or `.yaml`, it's assumed to contain CSL Data (i.e. Citation Style Language JSON).
-Otherwise, the format is inferred from the extension and converted to CSL JSON using the `pandoc-citeproc --bib2json` [utility](https://github.com/jgm/pandoc-citeproc/blob/master/man/pandoc-citeproc.1.md#convert-mode).
-The standard citation key for manual references is inferred from the CSL JSON `id` or `note` field.
-When no prefix is provided, such as `doi:`, `url:`, or `raw:`, a `raw:` prefix is automatically added.
-If multiple manual reference files load metadata for the same standard citation `id`, precedence is assigned according to descending filename order.
+These files are stored in the Pandoc metadata `bibliography` field, such that they can be loaded by `pandoc-manubot-cite`.
 
 ### Cite
 
@@ -203,7 +202,6 @@ This package creates the `pandoc-manubot-cite` Pandoc filter,
 providing access to Manubot's cite-by-ID functionality from within a Pandoc workflow.
 
 Currently, this filter is experimental and subject to breaking changes at any point.
-At some point in the future, we may migrate entirely from `manubot process` to `pandoc-manubot-cite` for citation processing.
 
 <!-- test codeblock contains output of `pandoc-manubot-cite --help` -->
 ```
@@ -230,6 +228,15 @@ Other Pandoc filters exist that do something similar:
 [`pwcite`](https://github.com/wikicite/wcite#filter-pwcite).
 Currently, `pandoc-manubot-cite` supports the most types of persistent identifiers.
 We're interested in creating as much compatibility as possible between these filters and their syntaxes.
+
+#### Manual references
+
+Manual references are loaded from the `references` and `bibliography` Pandoc metadata fields.
+If a manual reference filename ends with `.json` or `.yaml`, it's assumed to contain CSL Data (i.e. Citation Style Language JSON).
+Otherwise, the format is inferred from the extension and converted to CSL JSON using the `pandoc-citeproc --bib2json` [utility](https://github.com/jgm/pandoc-citeproc/blob/master/man/pandoc-citeproc.1.md#convert-mode).
+The standard citation key for manual references is inferred from the CSL JSON `id` or `note` field.
+When no prefix is provided, such as `doi:`, `url:`, or `raw:`, a `raw:` prefix is automatically added.
+If multiple manual reference files load metadata for the same standard citation `id`, precedence is assigned according to descending filename order.
 
 ### Webpage
 
@@ -308,6 +315,7 @@ portray as_html --overwrite --output_dir=docs
 manubot process \
   --content-directory=manubot/process/tests/manuscripts/example/content \
   --output-directory=manubot/process/tests/manuscripts/example/output \
+  --skip-citations \
   --log-level=INFO
 ```
 

--- a/manubot/cite/tests/test_unpaywall.py
+++ b/manubot/cite/tests/test_unpaywall.py
@@ -20,10 +20,14 @@ def test_unpaywall_arxiv():
 
 
 def test_unpaywall_from_citekey():
+    """
+    https://arxiv.org/abs/1906.11964 is now published in https://doi.org/10.1162/qss_a_00023.
+    Therefore, locations are coming from Unpaywall_DOI since defaulting to use_doi=True.
+    """
     unpaywall = Unpaywall.from_citekey("arxiv:1906.11964v3")
     assert isinstance(unpaywall, Unpaywall_arXiv)
     best_pdf = unpaywall.best_pdf
-    assert best_pdf["url_for_landing_page"] == "https://arxiv.org/abs/1906.11964v3"
+    assert "arxiv.org/abs/1906.11964" in best_pdf["url_for_landing_page"]
 
 
 def test_unpaywall_from_csl_item():

--- a/manubot/command.py
+++ b/manubot/command.py
@@ -75,11 +75,13 @@ def add_subparser_process(subparsers):
     parser.add_argument(
         "--skip-citations",
         action="store_true",
+        required=True,
         help="Skip citation and reference processing. "
-        "Specify when using the pandoc-manubot-cite filter. "
+        "Support for citation and reference processing has been moved from `manubot process` to the pandoc-manubot-cite filter. "
+        "Therefore this argument is now required. "
         "If citation-tags.tsv is found in content, "
         "these tags will be inserted in the markdown output using the reference-link syntax for citekey aliases. "
-        "Appends content/manual-references*.* paths to Pandoc's metadata.bibliography field.",
+        "Appends content/manual-references*.* paths to Pandoc's metadata.bibliography field. ",
     )
     parser.add_argument(
         "--cache-directory",

--- a/manubot/command.py
+++ b/manubot/command.py
@@ -81,7 +81,7 @@ def add_subparser_process(subparsers):
         "Therefore this argument is now required. "
         "If citation-tags.tsv is found in content, "
         "these tags will be inserted in the markdown output using the reference-link syntax for citekey aliases. "
-        "Appends content/manual-references*.* paths to Pandoc's metadata.bibliography field. ",
+        "Appends content/manual-references*.* paths to Pandoc's metadata.bibliography field.",
     )
     parser.add_argument(
         "--cache-directory",

--- a/manubot/process/manuscript.py
+++ b/manubot/process/manuscript.py
@@ -3,24 +3,6 @@ import datetime
 import json
 import logging
 import pathlib
-import re
-
-from manubot.cite.citekey import citekey_pattern, is_valid_citekey
-
-
-def get_citekeys(text):
-    """
-    Extract the deduplicated list of citations in a text. Citations that are
-    clearly invalid such as `doi:/453` are not returned.
-    """
-    citekeys = set(citekey_pattern.findall(text))
-    citekeys = filter(
-        lambda x: is_valid_citekey(
-            x, allow_tag=True, allow_raw=True, allow_pandoc_xnos=True
-        ),
-        citekeys,
-    )
-    return sorted(citekeys)
 
 
 def get_text(directory):

--- a/manubot/process/manuscript.py
+++ b/manubot/process/manuscript.py
@@ -37,41 +37,11 @@ def get_text(directory):
     return "\n\n".join(name_to_text.values()) + "\n"
 
 
-def update_manuscript_citekeys(text, old_to_new):
-    """
-    Replace citation keys according to the old_to_new dictionary.
-    Useful for converting citation keys to shortened versions
-    that are appropriate for pandoc.
-
-    `text` is markdown source text
-
-    `old_to_new` is a dictionary like:
-    doi:10.7287/peerj.preprints.3100v1 → 11cb5HXoY
-    """
-    for old, new in old_to_new.items():
-        text = re.sub(
-            pattern=re.escape("@" + old) + r"(?![\w:.#$%&\-+?<>~/]*[a-zA-Z0-9/])",
-            repl="@" + new,
-            string=text,
-        )
-    return text
-
-
-def get_manuscript_stats(text, citekeys_df=None):
+def get_manuscript_stats(text):
     """
     Compute manuscript statistics.
     """
     stats = collections.OrderedDict()
-
-    if citekeys_df is not None:
-        # Number of distinct references by type
-        ref_counts = (
-            citekeys_df.standard_citekey.drop_duplicates()
-            .map(lambda x: x.split(":")[0])
-            .pipe(collections.Counter)
-        )
-        ref_counts["total"] = sum(ref_counts.values())
-        stats["reference_counts"] = ref_counts
     stats["word_count"] = len(text.split())
     logging.info(f"Generated manscript stats:\n{json.dumps(stats, indent=2)}")
     return stats

--- a/manubot/process/tests/test_manuscript.py
+++ b/manubot/process/tests/test_manuscript.py
@@ -1,4 +1,4 @@
-from manubot.process.manuscript import get_citekeys, update_manuscript_citekeys
+from manubot.process.manuscript import get_citekeys
 
 
 def test_get_citekeys_1():
@@ -20,21 +20,3 @@ def test_get_citekeys_1():
         ]
     )
     assert citekeys == expected
-
-
-def test_update_manuscript_citekeys():
-    """
-    Test that text does not get converted to:
-
-    > our new Manubot tool [@cTN2TQIL-rootstock; @cTN2TQIL] for automating
-    manuscript generation.
-
-    See https://github.com/manubot/manubot/issues/9
-    """
-    string_to_id = {
-        "url:https://github.com/manubot/manubot": "mNMayr3f",
-        "url:https://github.com/greenelab/manubot-rootstock": "1B7Y2HVtw",
-    }
-    text = "our new Manubot tool [@url:https://github.com/greenelab/manubot-rootstock; @url:https://github.com/manubot/manubot] for automating manuscript generation."
-    text = update_manuscript_citekeys(text, string_to_id)
-    assert "[@1B7Y2HVtw; @mNMayr3f]" in text

--- a/manubot/process/tests/test_manuscript.py
+++ b/manubot/process/tests/test_manuscript.py
@@ -1,5 +1,0 @@
-from manubot.process.manuscript import datetime_now
-
-
-def test_datetime_now():
-    assert datetime_now()

--- a/manubot/process/tests/test_manuscript.py
+++ b/manubot/process/tests/test_manuscript.py
@@ -1,22 +1,5 @@
-from manubot.process.manuscript import get_citekeys
+from manubot.process.manuscript import datetime_now
 
 
-def test_get_citekeys_1():
-    text = """
-    Sci-Hub has released article request records from its server logs, covering 165 days from September 2015 through February 2016 [@doi:10.1126/science.352.6285.508; @doi:10.1126/science.aaf5664; @doi:10.5061/dryad.q447c/1].
-    We filtered for valid requests by excluding DOIs not included in our literature catalog and omitting requests that occurred before an article's publication date.
-
-    Figure {@fig:citescore}B shows that articles from highly cited journals were visited much more frequently on average.
-
-    @10.5061/bad_doi says blah but @url:https://www.courtlistener.com/docket/4355308/1/elsevier-inc-v-sci-hub/ disagrees.
-    """
-    citekeys = get_citekeys(text)
-    expected = sorted(
-        [
-            "doi:10.1126/science.352.6285.508",
-            "doi:10.1126/science.aaf5664",
-            "doi:10.5061/dryad.q447c/1",
-            "url:https://www.courtlistener.com/docket/4355308/1/elsevier-inc-v-sci-hub/",
-        ]
-    )
-    assert citekeys == expected
+def test_datetime_now():
+    assert datetime_now()

--- a/manubot/process/tests/test_process_command.py
+++ b/manubot/process/tests/test_process_command.py
@@ -14,8 +14,7 @@ manuscripts = [
 
 
 @pytest.mark.parametrize("manuscript", manuscripts)
-@pytest.mark.parametrize("skip_citations", [False, True])
-def test_example_manuscript(manuscript, skip_citations):
+def test_example_manuscript(manuscript):
     """
     Test command line execution of manubot to build an example manuscript.
     """
@@ -25,13 +24,12 @@ def test_example_manuscript(manuscript, skip_citations):
         "process",
         "--log-level",
         "INFO",
+        "--skip-citations",
         "--content-directory",
         str(manuscript_dir.joinpath("content")),
         "--output-directory",
         str(manuscript_dir.joinpath("output")),
     ]
-    if skip_citations:
-        args.append("--skip-citations")
     if manuscript == "variables":
         args.extend(
             [

--- a/manubot/process/util.py
+++ b/manubot/process/util.py
@@ -24,7 +24,6 @@ from manubot.process.metadata import (
 )
 from manubot.process.manuscript import (
     datetime_now,
-    get_citekeys,
     get_manuscript_stats,
     get_text,
 )
@@ -332,17 +331,6 @@ def read_citations_tsv(path) -> dict:
         zip(tag_df["manuscript_citekey"], tag_df["detagged_citekey"])
     )
     return citekey_aliases
-
-
-def _get_citekeys_df(args, text):
-    """
-    Generate citekeys_df from manubot process args and save it to 'citations.tsv'.
-    """
-    manuscript_citekeys = get_citekeys(text)
-    citekey_aliases = read_citations_tsv(args.citation_tags_path)
-    citekeys_df = get_citekeys_df(manuscript_citekeys, citekey_aliases)
-    write_citekeys_tsv(citekeys_df, args.citations_path)
-    return citekeys_df
 
 
 def write_citekeys_tsv(citekeys_df, path):


### PR DESCRIPTION
Remove support for citation processing in manubot process, in favor of using the pandoc-manubot-cite filter for all processing.

`pandoc-manubot-cite` does have a stricter syntax for what characters are allowed in citekeys. So we'll have to update the rootstock USAGE when upgrading manubot in Roostock.

My plan is to start more aggressively removing deprecated features like this to make the transition to `manubot/template` easier.