### PR TITLE
metadata: convert author.funders to list

### DIFF
--- a/manubot/process/tests/manuscripts/example/content/01.front-matter.md
+++ b/manubot/process/tests/manuscripts/example/content/01.front-matter.md
@@ -27,7 +27,7 @@ on {{manubot.date}}.
      {{author.affiliations | join('; ')}}
   {%- endif %}
   {%- if author.funders is defined %}
-     · Funded by {{author.funders}}
+     · Funded by {{author.funders | join('; ')}}
   {%- endif %}
   </small>
 {% endfor %}

--- a/manubot/process/tests/manuscripts/example/content/metadata.yaml
+++ b/manubot/process/tests/manuscripts/example/content/metadata.yaml
@@ -11,7 +11,8 @@ authors:
     twitter: dhimmel
     affiliations:
       - Department of Systems Pharmacology and Translational Therapeutics, University of Pennsylvania
-    funders: GBMF4552
+    funders:
+      - GBMF4552
   -
     github: agitter
     name: Anthony Gitter
@@ -21,4 +22,5 @@ authors:
     affiliations:
       - Department of Biostatistics and Medical Informatics, University of Wisconsin-Madison
       - Morgridge Institute for Research
-    funders: NIH U54AI117924
+    funders:
+      - NIH U54AI117924

--- a/manubot/process/util.py
+++ b/manubot/process/util.py
@@ -144,9 +144,12 @@ def _convert_field_to_list(
         if deprecation_warning_key:
             warnings.warn(
                 f"Expected list for {dictionary.get(deprecation_warning_key)}'s {field}. "
-                + (f"Assuming multiple {field} are `{separator}` separated. "
-                if separator
-                else "") + f"Please switch {field} to a list.",
+                + (
+                    f"Assuming multiple {field} are `{separator}` separated. "
+                    if separator
+                    else ""
+                )
+                + f"Please switch {field} to a list.",
                 category=DeprecationWarning,
             )
         return dictionary

--- a/manubot/process/util.py
+++ b/manubot/process/util.py
@@ -123,6 +123,36 @@ def read_variable_files(paths: List[str], variables: Optional[dict] = None) -> d
     return variables
 
 
+def _convert_field_to_list(
+    dictionary, field, separator=False, deprecation_warning_key=None
+):
+    """
+    Convert `dictionary[field]` to a list. If value is a string and
+    `separator` is specified, split by `separator`. If `deprecation_warning_key`
+    is provided, warn when `dictionary[field]` is a string.
+    """
+    if field not in dictionary:
+        return dictionary
+    value = dictionary[field]
+    if isinstance(value, list):
+        return dictionary
+    if isinstance(value, str):
+        if separator is False:
+            dictionary[field] = [value]
+        else:
+            dictionary[field] = value.split(separator)
+        if deprecation_warning_key:
+            warnings.warn(
+                f"Expected list for {dictionary.get(deprecation_warning_key)}'s {field}. "
+                + (f"Assuming multiple {field} are `{separator}` separated. "
+                if separator
+                else "") + f"Please switch {field} to a list.",
+                category=DeprecationWarning,
+            )
+        return dictionary
+    raise ValueError("Unsupported value type {value.__class__.__name__}")
+
+
 def add_author_affiliations(variables: dict) -> dict:
     """
     Edit variables to contain numbered author affiliations. Specifically,
@@ -132,17 +162,16 @@ def add_author_affiliations(variables: dict) -> dict:
     """
     rows = list()
     for author in variables["authors"]:
-        if "affiliations" not in author:
-            continue
-        if not isinstance(author["affiliations"], list):
-            warnings.warn(
-                f"Expected list for {author['name']}'s affiliations. "
-                f"Assuming multiple affiliations are `; ` separated. "
-                f"Please switch affiliations to a list.",
-                category=DeprecationWarning,
-            )
-            author["affiliations"] = author["affiliations"].split("; ")
-        for affiliation in author["affiliations"]:
+        _convert_field_to_list(
+            dictionary=author,
+            field="affiliations",
+            separator="; ",
+            deprecation_warning_key="name",
+        )
+        _convert_field_to_list(
+            dictionary=author, field="funders",
+        )
+        for affiliation in author.get("affiliations", []):
             rows.append((author["name"], affiliation))
     if not rows:
         return variables


### PR DESCRIPTION
refs https://github.com/manubot/rootstock/issues/329

In local output, got the following for legacy affiliations.

```
## WARNING
/home/dhimmel/Documents/repos/manubot/manubot/process/util.py:150: DeprecationWarning: Expected list for Daniel S. Himmelstein's affiliations. Assuming multiple affiliations are `; ` separated. Please switch affiliations to a list.
  category=DeprecationWarning,
```