### PR TITLE
reduce travis and appveyor CI duties

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,4 +25,4 @@ before_test:
   - ps: $env:Path += ";C:\Program Files\Pandoc\"
 
 test_script:
-  - "%CMD_IN_ENV% pytest -rs --color=yes"
+  - "%CMD_IN_ENV% pytest --color=yes -rs -m=appveyor"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,4 +25,4 @@ before_test:
   - ps: $env:Path += ";C:\Program Files\Pandoc\"
 
 test_script:
-  - "%CMD_IN_ENV% pytest --color=yes -rs -m=appveyor"
+  - "%CMD_IN_ENV% pytest --color=yes -rs -m='integration and appveyor'"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,4 +25,4 @@ before_test:
   - ps: $env:Path += ";C:\Program Files\Pandoc\"
 
 test_script:
-  - "%CMD_IN_ENV% pytest --color=yes -rs -m='integration and appveyor'"
+  - "%CMD_IN_ENV% pytest --color=yes -rs -m='integration or appveyor'"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,4 +25,4 @@ before_test:
   - ps: $env:Path += ";C:\Program Files\Pandoc\"
 
 test_script:
-  - "%CMD_IN_ENV% pytest --color=yes -rs -m='integration or appveyor'"
+  - '%CMD_IN_ENV% pytest --color=yes -rs -m="integration or appveyor"'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,8 +9,8 @@ environment:
     - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
-    - PYTHON: "C:\\Python37-x64"
-      PYTHON_VERSION: "3.7.x"
+    - PYTHON: "C:\\Python38-x64"
+      PYTHON_VERSION: "3.8.x"
       PYTHON_ARCH: "64"
 
 build: off

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,11 @@
 name: Tests
-
-on: [push, pull_request]
-
+on:
+- push
+- pull_request
 jobs:
-  test:
-    name: Test Python Code
+
+  pytest:
+    name: Python Test Suite
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 4
@@ -12,7 +13,6 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8]
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        pandoc-version: [2.9.2]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -21,7 +21,7 @@ jobs:
       with:
         # pandoc-versions from 2.7.3 to 2.9.1 won't install on Windows
         # https://github.com/jgm/pandoc/issues/6071
-        pandoc-version: ${{ matrix.pandoc-version }}
+        pandoc-version: 2.9.2
     - name: Install Python
       uses: actions/setup-python@v2
       with:
@@ -56,7 +56,7 @@ jobs:
       run: flake8
 
   docs:
-    name: Build docs
+    name: Build Docs
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ install:
   - pip install ".[all]"
   - python setup.py sdist bdist_wheel
 script:
-  - pytest -rs --color=yes
+  - pytest --color=yes -rs -m=appveyor

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ install:
   - pip install ".[all]"
   - python setup.py sdist bdist_wheel
 script:
-  - pytest --color=yes -rs -m=appveyor
+  - pytest --color=yes -rs -m=travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,15 @@ sudo: true
 language: python
 python:
   - "3.6"
-  - "3.7"
+  # - "3.7"  # test only the extremes
   - "3.8"
 cache:
   - pip
 before_install:
-  - wget --quiet https://github.com/jgm/pandoc/releases/download/2.9.2/pandoc-2.9.2-1-amd64.deb
-  - sudo dpkg --install pandoc-2.9.2-1-amd64.deb
+  - wget --quiet
+    --output-document=pandoc.deb
+    https://github.com/jgm/pandoc/releases/download/2.9.2/pandoc-2.9.2-1-amd64.deb
+  - sudo dpkg --install pandoc.deb
 install:
   - pip install ".[all]"
   - python setup.py sdist bdist_wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ install:
   - pip install ".[all]"
   - python setup.py sdist bdist_wheel
 script:
-  - pytest --color=yes -rs -m='integration and travis'
+  - pytest --color=yes -rs -m='integration or travis'

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ install:
   - pip install ".[all]"
   - python setup.py sdist bdist_wheel
 script:
-  - pytest --color=yes -rs -m=travis
+  - pytest --color=yes -rs -m='integration and travis'

--- a/conftest.py
+++ b/conftest.py
@@ -1,12 +1,17 @@
 import pytest
 
 
+markers = dict(
+    pandoc_version_sensitive="marks tests that require a specific version of pandoc to pass",
+    appveyor="marks tests where execution on AppVeyor provides additional coverage beyond GitHub Actions",
+    travis="marks tests where execution on Travis CI provides additional coverage beyond GitHub Actions",
+)
+
+
 def pytest_configure(config):
-    # register an additional marker
-    config.addinivalue_line(
-        "markers",
-        "pandoc_version_sensitive: marks tests that require a specific version of pandoc to pass",
-    )
+    # register additional markers
+    for k, v in markers.items():
+        config.addinivalue_line("markers", f"{k}: {v}")
 
 
 def pytest_addoption(parser):

--- a/conftest.py
+++ b/conftest.py
@@ -2,9 +2,10 @@ import pytest
 
 
 markers = dict(
-    pandoc_version_sensitive="marks tests that require a specific version of pandoc to pass",
+    integration="marks integration tests that cover large portions of the codebase and their interactions",
     appveyor="marks tests where execution on AppVeyor provides additional coverage beyond GitHub Actions",
     travis="marks tests where execution on Travis CI provides additional coverage beyond GitHub Actions",
+    pandoc_version_sensitive="marks tests that require a specific version of pandoc to pass",
 )
 
 

--- a/manubot/cite/tests/test_cite_command.py
+++ b/manubot/cite/tests/test_cite_command.py
@@ -48,6 +48,7 @@ def test_cite_command_file(tmpdir):
     assert csl["URL"] == "https://arxiv.org/abs/1806.05726v1"
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize(
     ["args", "filename"],
     [

--- a/manubot/pandoc/tests/test_cite_filter.py
+++ b/manubot/pandoc/tests/test_cite_filter.py
@@ -10,6 +10,7 @@ from manubot.util import shlex_join
 directory = pathlib.Path(__file__).parent
 
 
+@pytest.mark.integration
 @pytest.mark.pandoc_version_sensitive
 @pytest.mark.skipif(
     not shutil.which("pandoc"), reason="pandoc installation not found on system"

--- a/manubot/process/tests/test_ci.py
+++ b/manubot/process/tests/test_ci.py
@@ -33,6 +33,7 @@ def test_get_continuous_integration_parameters_github():
 @pytest.mark.skipif(
     os.getenv("TRAVIS_REPO_SLUG") != "manubot/manubot", reason="test fails on forks"
 )
+@pytest.mark.travis
 def test_get_continuous_integration_parameters_travis():
     info = get_continuous_integration_parameters()
     assert info is not None
@@ -53,6 +54,7 @@ def test_get_continuous_integration_parameters_travis():
 @pytest.mark.skipif(
     os.getenv("APPVEYOR_REPO_NAME") != "manubot/manubot", reason="test fails on forks"
 )
+@pytest.mark.appveyor
 def test_get_continuous_integration_parameters_appveyor():
     info = get_continuous_integration_parameters()
     assert info is not None

--- a/manubot/process/tests/test_process_command.py
+++ b/manubot/process/tests/test_process_command.py
@@ -13,6 +13,7 @@ manuscripts = [
 ]
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize("manuscript", manuscripts)
 def test_example_manuscript(manuscript):
     """

--- a/manubot/webpage/tests/test_webpage_command.py
+++ b/manubot/webpage/tests/test_webpage_command.py
@@ -33,5 +33,6 @@ def test_webpage_command():
         # Do not require OTS to succeed on GitHub Actions Windows to do libeay32 issue.
         # FIXME: Could not find module 'libeay32' (or one of its dependencies).
         # https://github.com/manubot/manubot/runs/488343989#step:6:123
+        # https://github.com/petertodd/python-bitcoinlib/issues/238
         return
     assert index_html_version_path.with_name("index.html.ots").exists()

--- a/manubot/webpage/tests/test_webpage_command.py
+++ b/manubot/webpage/tests/test_webpage_command.py
@@ -28,9 +28,4 @@ def test_webpage_command():
     index_html_version_path = webpage_path.joinpath("v/testing/index.html")
     for path in index_html_latest_path, index_html_version_path:
         assert filecmp.cmp(manuscript_html_path, path, shallow=False)
-    if os.environ.get("GITHUB_ACTIONS") == "true" and platform.system() == "Windows":
-        # Do not require OTS to succeed on GitHub Actions Windows to do libeay32 issue.
-        # FIXME: Could not find module 'libeay32' (or one of its dependencies).
-        # https://github.com/manubot/manubot/runs/488343989#step:6:123
-        return
     assert index_html_version_path.with_name("index.html.ots").exists()

--- a/manubot/webpage/tests/test_webpage_command.py
+++ b/manubot/webpage/tests/test_webpage_command.py
@@ -5,7 +5,10 @@ import platform
 import shutil
 import subprocess
 
+import pytest
 
+
+@pytest.mark.integration
 def test_webpage_command():
     manuscript_path = pathlib.Path(__file__).parent.joinpath("test-manuscript")
     webpage_path = manuscript_path.joinpath("webpage")

--- a/manubot/webpage/tests/test_webpage_command.py
+++ b/manubot/webpage/tests/test_webpage_command.py
@@ -9,6 +9,7 @@ import pytest
 
 
 @pytest.mark.integration
+@pytest.mark.appveyor
 def test_webpage_command():
     manuscript_path = pathlib.Path(__file__).parent.joinpath("test-manuscript")
     webpage_path = manuscript_path.joinpath("webpage")
@@ -28,4 +29,9 @@ def test_webpage_command():
     index_html_version_path = webpage_path.joinpath("v/testing/index.html")
     for path in index_html_latest_path, index_html_version_path:
         assert filecmp.cmp(manuscript_html_path, path, shallow=False)
+    if os.environ.get("GITHUB_ACTIONS") == "true" and platform.system() == "Windows":
+        # Do not require OTS to succeed on GitHub Actions Windows to do libeay32 issue.
+        # FIXME: Could not find module 'libeay32' (or one of its dependencies).
+        # https://github.com/manubot/manubot/runs/488343989#step:6:123
+        return
     assert index_html_version_path.with_name("index.html.ots").exists()


### PR DESCRIPTION
now that GitHub Actions is comprehensively testing and deploying,
use travis and appveyor only for tests where they provide unique
coverage.

Should help avoid intermittent failures from upstream resources
and avoid performing extra compute for little benefit.