### PR TITLE
one-time reset of the CSL JSON Schema requests cache

### DIFF
--- a/manubot/cite/citeproc.py
+++ b/manubot/cite/citeproc.py
@@ -10,6 +10,8 @@ import copy
 import functools
 import logging
 
+from manubot.util import read_serialized_data
+
 
 @functools.lru_cache()
 def get_jsonschema_csl_validator():
@@ -17,10 +19,9 @@ def get_jsonschema_csl_validator():
     Return a jsonschema validator for the CSL Item JSON Schema
     """
     import jsonschema
-    import requests
 
     url = "https://github.com/dhimmel/csl-schema/raw/manubot/csl-data.json"
-    schema = requests.get(url).json()
+    schema = read_serialized_data(url)
     Validator = jsonschema.validators.validator_for(schema)
     Validator.check_schema(schema)
     return Validator(schema)
@@ -97,7 +98,7 @@ def _remove_error(instance, error):
     Remove a jsonschema ValidationError from the JSON-like instance.
 
     See ValidationError documentation at
-    http://python-jsonschema.readthedocs.io/en/latest/errors/#jsonschema.exceptions.ValidationError
+    https://python-jsonschema.readthedocs.io/en/latest/errors/#jsonschema.exceptions.ValidationError
     """
     sub_errors = error.context
     if sub_errors:

--- a/manubot/util.py
+++ b/manubot/util.py
@@ -78,7 +78,8 @@ def read_serialized_data(path: str):
     supported_suffixes = {".json", ".yaml", ".yml", ".toml"}
     suffixes = set(path_lib.suffixes)
     if is_http_url(path_str):
-        response = requests.get(path_str)
+        headers = {"User-Agent": get_manubot_user_agent()}
+        response = requests.get(path_str, headers=headers)
         if not suffixes & supported_suffixes:
             # if URL has no supported suffixes, evaluate suffixes of final redirect
             suffixes = set(pathlib.Path(response.url).suffixes)


### PR DESCRIPTION
In 1c3c74b, we upgraded the CSL JSON Schema at
https://github.com/dhimmel/csl-schema/raw/manubot/csl-data.json
and updated get_jsonschema_csl_validator in a way that requires
the new schema.

However, this caused rootstock repo pull request to fail after
upgrading manubot because the outdated csl-data.json schema was cached.
https://github.com/manubot/rootstock/pull/342#issuecomment-633309646

This should work because we set include_get_headers=True in
requests_cache.install_cache.

Another options would be

with requests_cache.disabled():
    requests.get(url)

https://requests-cache.readthedocs.io/en/latest/api.html#requests_cache.core.disabled