### PR TITLE
cite command enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ subcommands:
 
   {process,cite,webpage}
     process             process manuscript content
-    cite                citation to CSL command line utility
+    cite                citekey to CSL JSON command line utility
     webpage             deploy Manubot outputs to a webpage directory tree
 ```
 
@@ -150,15 +150,18 @@ These files are stored in the Pandoc metadata `bibliography` field, such that th
 
 ### Cite
 
-`manubot cite` is a command line utility to create [CSL JSON items](http://citeproc-js.readthedocs.io/en/latest/csl-json/markup.html#items) for one or more citation keys.
-Citation keys should be in the format `source:identifier`.
-For example, the following example generates CSL JSON for four references:
+`manubot cite` is a command line utility to produce bibliographic metadata for citation keys.
+The utility either outputs metadata as [CSL JSON items](http://citeproc-js.readthedocs.io/en/latest/csl-json/markup.html#items) or produces formatted references if `--render`.
 
-```sh
-manubot cite doi:10.1098/rsif.2017.0387 pubmed:29424689 pmc:PMC5640425 arxiv:1806.05726
+Citation keys should be in the format `prefix:accession`.
+For example, the following example generates Markdown-formatted references for four persistent identifiers:
+
+```shell
+manubot cite --format=markdown \
+  doi:10.1098/rsif.2017.0387 pubmed:29424689 pmc:PMC5640425 arxiv:1806.05726
 ```
 
-The following [terminal recording](https://asciinema.org/a/205085?speed=2) demonstrates the main features of `manubot cite`:
+The following [terminal recording](https://asciinema.org/a/205085?speed=2) demonstrates the main features of `manubot cite` (for a slightly outdated version):
 
 ![manubot cite demonstration](media/terminal-recordings/manubot-cite-cast.gif)
 
@@ -172,12 +175,13 @@ usage: manubot cite [-h] [--output OUTPUT] [--render]
                     [--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
                     citekeys [citekeys ...]
 
-Retrieve bibliographic metadata for one or more citation keys. Text outputs
-are UTF-8 encoded.
+Generate bibliographic metadata in CSL JSON format for one or more citation
+keys. Optionally, render metadata into formatted references using Pandoc. Text
+outputs are UTF-8 encoded.
 
 positional arguments:
-  citekeys              One or more (space separated) citation keys to produce
-                        CSL for.
+  citekeys              One or more (space separated) citation keys to
+                        generate bibliographic metadata for.
 
 optional arguments:
   -h, --help            show this help message and exit

--- a/README.md
+++ b/README.md
@@ -166,9 +166,9 @@ Additional usage information is available from `manubot cite --help`:
 
 <!-- test codeblock contains output of `manubot cite --help` -->
 ```
-usage: manubot cite [-h] [--render] [--csl CSL] [--bibliography BIBLIOGRAPHY]
-                    [--format {plain,markdown,docx,html,jats}]
-                    [--output OUTPUT] [--allow-invalid-csl-data]
+usage: manubot cite [-h] [--output OUTPUT] [--render]
+                    [--format {plain,markdown,docx,html,jats}] [--csl CSL]
+                    [--bibliography BIBLIOGRAPHY] [--allow-invalid-csl-data]
                     [--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
                     citekeys [citekeys ...]
 
@@ -180,23 +180,23 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
+  --output OUTPUT       Specify a file to write output, otherwise default to
+                        stdout.
   --render              Whether to render CSL Data into a formatted reference
                         list using Pandoc. Pandoc version 2.0 or higher is
                         required for complete support of available output
                         formats.
-  --csl CSL             When --render, specify an XML CSL definition to style
-                        references (i.e. Pandoc's --csl option). Defaults to
-                        Manubot's style.
+  --format {plain,markdown,docx,html,jats}
+                        Format to use for output file. Implies --render. If
+                        not specified, attempt to infer this from the --output
+                        filename extension. Otherwise, default to plain.
+  --csl CSL             Specify an XML CSL definition to style references
+                        (i.e. Pandoc's --csl option). Implies --render.
+                        Defaults to Manubot's style.
   --bibliography BIBLIOGRAPHY
                         File to read manual reference metadata. Specify
                         multiple times to load multiple files. Similar to
                         pandoc --bibliography.
-  --format {plain,markdown,docx,html,jats}
-                        When --render, format to use for output file. If not
-                        specified, attempt to infer this from filename
-                        extension. Otherwise, default to plain.
-  --output OUTPUT       Specify a file to write output, otherwise default to
-                        stdout.
   --allow-invalid-csl-data
                         Allow CSL Items that do not conform to the JSON
                         Schema. Skips CSL pruning.

--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ usage: manubot cite [-h] [--output OUTPUT] [--render]
                     [--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
                     citekeys [citekeys ...]
 
-Retrieve bibliographic metadata for one or more citation keys.
+Retrieve bibliographic metadata for one or more citation keys. Text outputs
+are UTF-8 encoded.
 
 positional arguments:
   citekeys              One or more (space separated) citation keys to produce

--- a/manubot/cite/cite_command.py
+++ b/manubot/cite/cite_command.py
@@ -68,7 +68,7 @@ def cli_cite(args):
     inconsistent citation rendering by output format. See
     https://github.com/jgm/pandoc/issues/4834
     """
-    citations = Citations(args.citekeys)
+    citations = Citations(input_ids=args.citekeys, prune_csl_items=args.prune_csl,)
     citations.load_manual_references(paths=args.bibliography)
     citations.inspect(log_level="WARNING")
     csl_items = citations.get_csl_items()
@@ -97,7 +97,7 @@ def _exit_without_pandoc():
     for command in "pandoc", "pandoc-citeproc":
         if not info[command]:
             logging.critical(
-                f'"{command}" not found on system. ' f"Check that Pandoc is installed."
+                f"{command!r} not found on system. Check that Pandoc is installed."
             )
             raise SystemExit(1)
 

--- a/manubot/cite/cite_command.py
+++ b/manubot/cite/cite_command.py
@@ -21,8 +21,7 @@ extension_to_format = {
 URL or path with default CSL XML style.
 <https://citation-style.manubot.org> redirects to the latest Manubot CSL Style.
 """
-# todo add HTTPS in 48 hours
-default_csl_style_path = "http://citation-style.manubot.org/"
+default_csl_style_path = "https://citation-style.manubot.org/"
 
 
 def call_pandoc(metadata, path, format="plain"):

--- a/manubot/cite/cite_command.py
+++ b/manubot/cite/cite_command.py
@@ -17,9 +17,12 @@ extension_to_format = {
     ".xml": "jats",
 }
 
-default_csl_style_path = (
-    "https://github.com/manubot/rootstock/raw/master/build/assets/style.csl"
-)
+"""
+URL or path with default CSL XML style.
+<https://citation-style.manubot.org> redirects to the latest Manubot CSL Style.
+"""
+# todo add HTTPS in 48 hours
+default_csl_style_path = "http://citation-style.manubot.org/"
 
 
 def call_pandoc(metadata, path, format="plain"):

--- a/manubot/command.py
+++ b/manubot/command.py
@@ -99,15 +99,28 @@ def add_subparser_cite(subparsers):
         description="Retrieve bibliographic metadata for one or more citation keys.",
     )
     parser.add_argument(
+        "--output",
+        type=pathlib.Path,
+        help="Specify a file to write output, otherwise default to stdout.",
+    )
+    parser.add_argument(
         "--render",
         action="store_true",
         help="Whether to render CSL Data into a formatted reference list using Pandoc. "
         "Pandoc version 2.0 or higher is required for complete support of available output formats.",
     )
     parser.add_argument(
+        "--format",
+        choices=["plain", "markdown", "docx", "html", "jats"],
+        help="Format to use for output file. "
+        "Implies --render. "
+        "If not specified, attempt to infer this from the --output filename extension. "
+        "Otherwise, default to plain.",
+    )
+    parser.add_argument(
         "--csl",
-        default="https://github.com/greenelab/manubot-rootstock/raw/master/build/assets/style.csl",
-        help="When --render, specify an XML CSL definition to style references (i.e. Pandoc's --csl option). "
+        help="Specify an XML CSL definition to style references (i.e. Pandoc's --csl option). "
+        "Implies --render. "
         "Defaults to Manubot's style.",
     )
     parser.add_argument(
@@ -117,18 +130,6 @@ def add_subparser_cite(subparsers):
         help="File to read manual reference metadata. "
         "Specify multiple times to load multiple files. "
         "Similar to pandoc --bibliography.",
-    )
-    parser.add_argument(
-        "--format",
-        choices=["plain", "markdown", "docx", "html", "jats"],
-        help="When --render, format to use for output file. "
-        "If not specified, attempt to infer this from filename extension. "
-        "Otherwise, default to plain.",
-    )
-    parser.add_argument(
-        "--output",
-        type=pathlib.Path,
-        help="Specify a file to write output, otherwise default to stdout.",
     )
     parser.add_argument(
         "--allow-invalid-csl-data",

--- a/manubot/command.py
+++ b/manubot/command.py
@@ -95,8 +95,9 @@ def add_subparser_process(subparsers):
 def add_subparser_cite(subparsers):
     parser = subparsers.add_parser(
         name="cite",
-        help="citation to CSL command line utility",
-        description="Retrieve bibliographic metadata for one or more citation keys. "
+        help="citekey to CSL JSON command line utility",
+        description="Generate bibliographic metadata in CSL JSON format for one or more citation keys. "
+        "Optionally, render metadata into formatted references using Pandoc. "
         "Text outputs are UTF-8 encoded.",
     )
     parser.add_argument(
@@ -141,7 +142,7 @@ def add_subparser_cite(subparsers):
     parser.add_argument(
         "citekeys",
         nargs="+",
-        help="One or more (space separated) citation keys to produce CSL for.",
+        help="One or more (space separated) citation keys to generate bibliographic metadata for.",
     )
     parser.set_defaults(function="manubot.cite.cite_command.cli_cite")
 

--- a/manubot/command.py
+++ b/manubot/command.py
@@ -96,7 +96,8 @@ def add_subparser_cite(subparsers):
     parser = subparsers.add_parser(
         name="cite",
         help="citation to CSL command line utility",
-        description="Retrieve bibliographic metadata for one or more citation keys.",
+        description="Retrieve bibliographic metadata for one or more citation keys. "
+        "Text outputs are UTF-8 encoded.",
     )
     parser.add_argument(
         "--output",

--- a/manubot/pandoc/bibliography.py
+++ b/manubot/pandoc/bibliography.py
@@ -56,10 +56,15 @@ def load_bibliography(path=None, text=None, input_format=None):
         **run_kwargs,
     )
     logging.info(f"captured stderr:\n{process.stderr}")
-    process.check_returncode()
+    if process.returncode:
+        logging.error(
+            f"Pandoc call returned nonzero exit code.\n"
+            f"{shlex_join(process.args)}\n{process.stderr}"
+        )
+        return []
     try:
         csl_json = json.loads(process.stdout)
     except Exception:
-        logging.exception(f"Error parsing bib2json output as JSON:\n{process.stdout}")
+        logging.error(f"Error parsing bib2json output as JSON:\n{process.stdout}")
         csl_json = []
     return csl_json

--- a/manubot/pandoc/bibliography.py
+++ b/manubot/pandoc/bibliography.py
@@ -6,12 +6,13 @@ from manubot.pandoc.util import get_pandoc_info
 from manubot.util import shlex_join
 
 
-def load_bibliography(path=None, text=None, input_format=None):
+def load_bibliography(path=None, text=None, input_format=None) -> list:
     """
     Convert a bibliography to CSL JSON using `pandoc-citeproc --bib2json`.
     Accepts either a bibliography path or text (string). If supplying text,
     pandoc-citeproc will likely require input_format be specified.
     The CSL JSON is returned as Python objects.
+    If loading fails, log an error and return an empty list.
 
     Parameters
     ----------

--- a/manubot/process/bibliography.py
+++ b/manubot/process/bibliography.py
@@ -12,7 +12,9 @@ def load_bibliography(path: str) -> list:
     """
     Load a bibliography as CSL Items (a CSL JSON Python object).
     For paths that already contain CSL Items (inferred from a .json or .yaml extension),
-    parse these files directly. Otherwise, delegate conversion to CSL Items to pandoc-citeproc.
+    parse these files directly (URLs supported).
+    Otherwise, delegate conversion to CSL Items to pandoc-citeproc (URLs not supported).
+    If loading fails, log an error and return an empty list.
     """
     path_obj = pathlib.Path(path)
     if path_obj.suffix in {".json", ".yaml"}:

--- a/manubot/util.py
+++ b/manubot/util.py
@@ -74,9 +74,9 @@ def read_serialized_data(path: str):
     import requests
 
     path_str = os.fspath(path)
-    path_lib = pathlib.Path(path)
+    path_obj = pathlib.Path(path)
     supported_suffixes = {".json", ".yaml", ".yml", ".toml"}
-    suffixes = set(path_lib.suffixes)
+    suffixes = set(path_obj.suffixes)
     if is_http_url(path_str):
         headers = {"User-Agent": get_manubot_user_agent()}
         response = requests.get(path_str, headers=headers)
@@ -85,7 +85,7 @@ def read_serialized_data(path: str):
             suffixes = set(pathlib.Path(response.url).suffixes)
         text = response.text
     else:
-        text = path_lib.read_text(encoding="utf-8-sig")
+        text = path_obj.read_text(encoding="utf-8-sig")
     if {".yaml", ".yml"} & suffixes:
         import yaml
 


### PR DESCRIPTION
- fixup 47b03e0c202e6a0561e6548ba08a4ad790f56eee reenable --allow-invalid-csl-data
- --csl or --format implies --render
- reorder args so most common ones first
- switch URL for default CSL Style to https://citation-style.manubot.org/
- enable `--bibliography` as URL for `.json` or `.yaml` files. Pandoc does not support URL for `--bibliography` yet