### PR TITLE
Add typing to manubot.cite.pubmed

### DIFF
--- a/manubot/cite/citekey.py
+++ b/manubot/cite/citekey.py
@@ -22,18 +22,18 @@ class CiteKey:
         self.check_input_id(self.input_id)
 
     @staticmethod
-    def check_input_id(input_id):
+    def check_input_id(input_id) -> None:
         if not isinstance(input_id, str):
             raise TypeError(
                 "input_id should be type 'str' not "
                 f"{type(input_id).__name__!r}: {input_id!r}"
             )
         if input_id.startswith("@"):
-            f"invalid citekey input_id: {input_id!r}\nstarts with '@'"
+            raise ValueError(f"invalid citekey input_id: {input_id!r}\nstarts with '@'")
 
     @classmethod
     @functools.lru_cache(maxsize=None)
-    def from_input_id(cls, *args, **kwargs):
+    def from_input_id(cls, *args, **kwargs) -> "CiteKey":
         """Cached constructor"""
         return cls(*args, **kwargs)
 
@@ -45,7 +45,7 @@ class CiteKey:
         """
         return self.aliases.get(self.input_id, self.input_id)
 
-    def _set_prefix_accession(self):
+    def _set_prefix_accession(self) -> None:
         try:
             prefix, accession = self.dealiased_id.split(":", 1)
         except ValueError:
@@ -123,7 +123,7 @@ class CiteKey:
         """
         return self.handler.inspect(self)
 
-    def _standardize(self):
+    def _standardize(self) -> None:
         """
         Set `self._standard_prefix`, `self._standard_accession`, and `self._standard_id`.
         For citekeys without a prefix or with an unhandled prefix, _standard_prefix
@@ -157,7 +157,7 @@ class CiteKey:
         return shorten_citekey(self.standard_id)
 
     @cached_property
-    def all_ids(self):
+    def all_ids(self) -> tp.List[str]:
         ids = [self.input_id, self.dealiased_id, self.standard_id, self.short_id]
         ids = [x for x in ids if x]  # remove None
         ids = list(dict.fromkeys(ids))  # deduplicate
@@ -189,7 +189,7 @@ class CiteKey:
         csl_item.set_id(self.standard_id)
         return csl_item
 
-    def is_pandoc_xnos_prefix(self, log_case_warning=False):
+    def is_pandoc_xnos_prefix(self, log_case_warning: bool = False) -> bool:
         from .handlers import _pandoc_xnos_prefixes
 
         if self.prefix in _pandoc_xnos_prefixes:
@@ -258,7 +258,7 @@ def citekey_to_csl_item(
     return csl_item
 
 
-def url_to_citekey(url):
+def url_to_citekey(url: str) -> str:
     """
     Convert a HTTP(s) URL into a citekey.
     For supported sources, convert from url citekey to an alternative source like doi.

--- a/manubot/cite/csl_item.py
+++ b/manubot/cite/csl_item.py
@@ -24,9 +24,10 @@ for csl_data that is JSON-serialized.
 """
 
 import copy
+import datetime
 import logging
 import re
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from manubot.cite.citekey import CiteKey
 
@@ -149,7 +150,11 @@ class CSL_Item(dict):
             self.validate_against_schema()
         return self
 
-    def set_date(self, date, variable="issued"):
+    def set_date(
+        self,
+        date: Union[None, str, datetime.date, datetime.datetime],
+        variable="issued",
+    ):
         """
         date: date either as a string (in the form YYYY, YYYY-MM, or YYYY-MM-DD)
             or as a Python date object (datetime.date or datetime.datetime).
@@ -160,7 +165,7 @@ class CSL_Item(dict):
             self[variable] = {"date-parts": [date_parts]}
         return self
 
-    def get_date(self, variable="issued", fill=False):
+    def get_date(self, variable: str = "issued", fill: bool = False):
         """
         Return a CSL date-variable as ISO formatted string:
         ('YYYY', 'YYYY-MM', 'YYYY-MM-DD', or None).
@@ -297,15 +302,15 @@ def assert_csl_item_type(x):
         raise TypeError(f"Expected CSL_Item object, got {type(x)}")
 
 
-def date_to_date_parts(date) -> Optional[List[int]]:
+def date_to_date_parts(
+    date: Union[None, str, datetime.date, datetime.datetime]
+) -> Optional[List[int]]:
     """
     Convert a date string or object to a date parts list.
 
     date: date either as a string (in the form YYYY, YYYY-MM, or YYYY-MM-DD)
         or as a Python date object (datetime.date or datetime.datetime).
     """
-    import datetime
-
     if date is None:
         return None
     if isinstance(date, (datetime.date, datetime.datetime)):
@@ -337,6 +342,7 @@ def date_to_date_parts(date) -> Optional[List[int]]:
         date_parts.append(int(value))
     if date_parts:
         return date_parts
+    return None
 
 
 def date_parts_to_string(date_parts, fill: bool = False) -> Optional[str]:

--- a/manubot/cite/handlers.py
+++ b/manubot/cite/handlers.py
@@ -2,9 +2,10 @@ import abc
 import dataclasses
 import functools
 import re
-import typing
+from typing import Optional, Dict, Pattern, Tuple, Any
 
 from manubot.util import import_function
+from .citekey import CiteKey
 
 """
 Non-citation prefixes used by the pandoc-xnos suite of Pandoc filters,
@@ -25,7 +26,7 @@ _local_handlers = [
 
 
 @functools.lru_cache(maxsize=10_000)
-def get_handler(prefix_lower):
+def get_handler(prefix_lower: str) -> "Handler":
     if not isinstance(prefix_lower, str):
         raise TypeError(
             f"prefix_lower should be a str, instead received {prefix_lower.__class__.__name__}"
@@ -36,7 +37,7 @@ def get_handler(prefix_lower):
     return handler
 
 
-def _generate_prefix_to_handler() -> typing.Dict[str, str]:
+def _generate_prefix_to_handler() -> Dict[str, str]:
     """
     Generate complete dictionary for prefix_to_handler.
     """
@@ -69,7 +70,7 @@ class Handler:
     prefix_lower: str
     prefixes = []
 
-    def _get_pattern(self, attribute="accession_pattern") -> typing.Pattern:
+    def _get_pattern(self, attribute="accession_pattern") -> Pattern:
         """
         Return a compiled regex pattern stored by `attribute`.
         By default, return `self.accession_pattern`, which Handler subclasses
@@ -79,11 +80,11 @@ class Handler:
         pattern = getattr(self, attribute, None)
         if not pattern:
             return None
-        if not isinstance(pattern, typing.Pattern):
+        if not isinstance(pattern, Pattern):
             pattern = re.compile(pattern)
         return pattern
 
-    def inspect(self, citekey):
+    def inspect(self, citekey: CiteKey) -> Optional[str]:
         """
         Check citekeys adhere to expected formats. If an issue is detected a
         string describing the issue is returned. Otherwise returns None.
@@ -94,7 +95,7 @@ class Handler:
         if not pattern.fullmatch(citekey.accession):
             return f"{citekey.accession} does not match regex {pattern.pattern}"
 
-    def standardize_prefix_accession(self, accession):
+    def standardize_prefix_accession(self, accession: str) -> Tuple[str, str]:
         """
         Return (prefix, accession) in standardized form.
         This method defaults to returning `self.standard_prefix`
@@ -106,7 +107,7 @@ class Handler:
         return standard_prefix, standard_accession
 
     @abc.abstractmethod
-    def get_csl_item(self, citekey):
+    def get_csl_item(self, citekey) -> Dict[str, Any]:
         """
         Return a CSL_Item with bibliographic details for citekey.
         """
@@ -121,7 +122,7 @@ This output is automatically generated using `_generate_prefix_to_handler`.
 Hardcoding this mapping reduces startup time and helps keep imports to a minimum,
 allowing installations without the full dependencies to function.
 """
-prefix_to_handler: typing.Dict[str, str] = {
+prefix_to_handler: Dict[str, str] = {
     "3dmet": "manubot.cite.curie.Handler_CURIE",
     "abs": "manubot.cite.curie.Handler_CURIE",
     "aceview.worm": "manubot.cite.curie.Handler_CURIE",

--- a/manubot/cite/pubmed.py
+++ b/manubot/cite/pubmed.py
@@ -137,7 +137,7 @@ def get_pubmed_csl_item(pmid: Union[str, int]) -> Dict[str, Any]:
         assert isinstance(xml_article_set, ElementTree.Element)
         assert xml_article_set.tag == "PubmedArticleSet"
         (xml_article,) = list(xml_article_set)
-        assert xml_article.tag == "PubmedArticle"
+        assert xml_article.tag in ["PubmedArticle", "PubmedBookArticle"]
     except Exception as error:
         logging.error(
             f"Error fetching PubMed metadata for {pmid}.\n"

--- a/manubot/cite/pubmed.py
+++ b/manubot/cite/pubmed.py
@@ -1,13 +1,14 @@
 import functools
 import json
 import logging
-import xml.etree.ElementTree
+from xml.etree import ElementTree
+from typing import List, Optional, Dict, Any, Union
 
 import requests
 
+from .citekey import CiteKey
 from .handlers import Handler
 from manubot.util import get_manubot_user_agent
-
 
 class Handler_PubMed(Handler):
 
@@ -19,7 +20,7 @@ class Handler_PubMed(Handler):
     ]
     accession_pattern = r"[1-9][0-9]{0,7}"
 
-    def inspect(self, citekey):
+    def inspect(self, citekey: CiteKey) -> Optional[str]:
         identifier = citekey.accession
         # https://www.nlm.nih.gov/bsd/mms/medlineelements.html#pmid
         if identifier.startswith("PMC"):
@@ -30,7 +31,7 @@ class Handler_PubMed(Handler):
         elif not self._get_pattern().fullmatch(identifier):
             return "PubMed Identifiers should be 1-8 digits with no leading zeros."
 
-    def get_csl_item(self, citekey):
+    def get_csl_item(self, citekey: CiteKey):
         return get_pubmed_csl_item(citekey.standard_accession)
 
 
@@ -43,7 +44,7 @@ class Handler_PMC(Handler):
     ]
     accession_pattern = r"PMC[0-9]+"
 
-    def inspect(self, citekey):
+    def inspect(self, citekey: CiteKey) -> Optional[str]:
         identifier = citekey.accession
         # https://www.nlm.nih.gov/bsd/mms/medlineelements.html#pmc
         if not identifier.startswith("PMC"):
@@ -54,11 +55,11 @@ class Handler_PMC(Handler):
                 "Double check the PMCID."
             )
 
-    def get_csl_item(self, citekey):
+    def get_csl_item(self, citekey: CiteKey):
         return get_pmc_csl_item(citekey.standard_accession)
 
 
-def get_pmc_csl_item(pmcid):
+def get_pmc_csl_item(pmcid: str) -> Dict[str, Any]:
     """
     Get the CSL Item for a PubMed Central record by its PMID, PMCID, or
     DOI, using the NCBI Citation Exporter API.
@@ -115,7 +116,7 @@ def _get_literature_citation_exporter_csl_item(database, identifier):
     return csl_item
 
 
-def get_pubmed_csl_item(pmid):
+def get_pubmed_csl_item(pmid: Union[str, int]):
     """
     Query NCBI E-Utilities to create CSL Items for PubMed IDs.
 
@@ -129,16 +130,19 @@ def get_pubmed_csl_item(pmid):
     with _get_eutils_rate_limiter():
         response = requests.get(url, params, headers=headers)
     try:
-        element_tree = xml.etree.ElementTree.fromstring(response.text)
-        (element_tree,) = list(element_tree)
+        xml_article_set = ElementTree.fromstring(response.text)
+        assert isinstance(xml_article_set, ElementTree.Element)
+        assert xml_article_set.tag == "PubmedArticleSet"
+        (xml_article,) = list(xml_article_set)
+        assert xml_article.tag == "PubmedArticle"
     except Exception as error:
         logging.error(
             f"Error fetching PubMed metadata for {pmid}.\n"
-            f"Invalid XML response from {response.url}:\n{response.text}"
+            f"Unsupported XML response from {response.url}:\n{response.text}"
         )
         raise error
     try:
-        csl_item = csl_item_from_pubmed_article(element_tree)
+        csl_item = csl_item_from_pubmed_article(xml_article)
     except Exception as error:
         msg = f"Error parsing the following PubMed metadata for PMID {pmid}:\n{response.text}"
         logging.error(msg)
@@ -146,12 +150,14 @@ def get_pubmed_csl_item(pmid):
     return csl_item
 
 
-def csl_item_from_pubmed_article(article):
+def csl_item_from_pubmed_article(article: ElementTree.Element) -> Dict[str, Any]:
     """
-    article is a PubmedArticle xml element tree
-
+    Extract a CSL Item dictionary from a PubmedArticle XML element.
     https://github.com/citation-style-language/schema/blob/master/csl-data.json
     """
+    if not article.tag == "PubmedArticle":
+        raise ValueError(f"Expected article to be an XML element with tag PubmedArticle, received tag {article.tag!r}")
+
     csl_item = dict()
 
     if not article.find("MedlineCitation/Article"):
@@ -219,7 +225,7 @@ def csl_item_from_pubmed_article(article):
     return csl_item
 
 
-month_abbrev_to_int = {
+month_abbrev_to_int: Dict[str, int] = {
     "Jan": 1,
     "Feb": 2,
     "Mar": 3,
@@ -235,7 +241,7 @@ month_abbrev_to_int = {
 }
 
 
-def extract_publication_date_parts(article):
+def extract_publication_date_parts(article) -> List[int]:
     """
     Extract date published from a PubmedArticle xml element tree.
     """
@@ -283,7 +289,7 @@ def get_pmcid_and_pmid_for_doi(doi):
         logging.warning(f"Status code {response.status_code} querying {response.url}\n")
         return {}
     try:
-        element_tree = xml.etree.ElementTree.fromstring(response.text)
+        element_tree = ElementTree.Element.fromstring(response.text)
     except Exception:
         logging.warning(
             f"Error fetching PMC ID conversion for {doi}.\n"
@@ -323,7 +329,7 @@ def get_pmid_for_doi(doi):
         logging.warning(f"Status code {response.status_code} querying {response.url}\n")
         return None
     try:
-        element_tree = xml.etree.ElementTree.fromstring(response.text)
+        element_tree = ElementTree.Element.fromstring(response.text)
     except Exception:
         logging.warning(
             f"Error in ESearch XML for DOI: {doi}.\n"

--- a/manubot/cite/tests/test_citekey.py
+++ b/manubot/cite/tests/test_citekey.py
@@ -78,6 +78,20 @@ def test_citekey_class(input_id, citekey_attrs):
     assert citekey.short_id
 
 
+def test_citekey_check_input_id_type():
+    with pytest.raises(TypeError) as excinfo:
+        CiteKey(None)
+    assert "input_id should be type 'str' not 'NoneType': None" == str(excinfo.value)
+    with pytest.raises(TypeError):
+        CiteKey(0)
+
+
+def test_citekey_check_input_id_at_prefix():
+    with pytest.raises(ValueError) as excinfo:
+        CiteKey("@my-citekey")
+    assert "input_id: '@my-citekey'\nstarts with '@'" in str(excinfo.value)
+
+
 @pytest.mark.parametrize(
     "standard_citekey,expected",
     [

--- a/manubot/cite/tests/test_citekey_api.py
+++ b/manubot/cite/tests/test_citekey_api.py
@@ -157,7 +157,10 @@ def test_citekey_to_csl_item_pubmed_book(caplog):
     """
     csl_item = citekey_to_csl_item("pmid:29227604", log_level="ERROR")
     assert csl_item is None
-    assert "Unsupported PubMed record: no <Article> element" in caplog.text
+    assert (
+        "Expected article to be an XML element with tag PubmedArticle, received tag 'PubmedBookArticle'"
+        in caplog.text
+    )
 
 
 def test_citekey_to_csl_item_isbn():

--- a/manubot/util.py
+++ b/manubot/util.py
@@ -10,10 +10,10 @@ import subprocess
 import sys
 
 # Email address that forwards to Manubot maintainers
-contact_email = "contact@manubot.org"
+contact_email: str = "contact@manubot.org"
 
 
-def import_function(name):
+def import_function(name: str):
     """
     Import a function in a module specified by name. For example, if name were
     'manubot.cite.cite_command.cli_cite', the cli_cite function would be
@@ -24,7 +24,7 @@ def import_function(name):
     return getattr(module, function_name)
 
 
-def get_manubot_user_agent():
+def get_manubot_user_agent() -> str:
     """
     Return a User-Agent string for web request headers to help services
     identify requests as coming from Manubot.
@@ -40,7 +40,7 @@ def get_manubot_user_agent():
     )
 
 
-def shlex_join(split_command):
+def shlex_join(split_command) -> str:
     """
     Backport shlex.join for Python < 3.8.
     Also cast all args to str to increase versatility.
@@ -51,7 +51,7 @@ def shlex_join(split_command):
 
 
 """Valid schemes for HTTP URL detection"""
-_http_url_schemes = {"http", "https"}
+_http_url_schemes: set = {"http", "https"}
 
 
 def is_http_url(string: str) -> bool:


### PR DESCRIPTION
I'd like to begin more comprehensively typing this package, with the eventual goal of running a static type checker like mypy. In the meantime, these types help as documentation.