### PR TITLE
Use pre-commit hooks for formatting and linting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,24 +62,16 @@ jobs:
       run: |
         pytest -rs --color=yes
 
-  lint:
-    name: Lint Python Code
+  pre-commit:
+    name: Pre-Commit Checks
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Install Python
       uses: actions/setup-python@v2
-    - name: Install dependencies
-      run: pip install black flake8
-    - name: Check formatting
-      run: |
-        # if the following command fails, run `black .` locally to reformat the code.
-        # ensure your local version of black matches the version installed on CI,
-        # which will usually be the latest version from https://pypi.org/project/black/
-        black --check --diff .
-    - name: Check style
-      run: flake8
+    - name: Run checks
+      uses: pre-commit/action@v2.0.0
 
   docs:
     name: Build Docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,10 +2,17 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.3.0
     hooks:
+      # Check for files that contain merge conflict strings.
       - id: check-merge-conflict
+      # Check for debugger imports and py37+ `breakpoint()` calls in python source.
       - id: debug-statements
+      # Replaces or checks mixed line ending
       - id: mixed-line-ending
+      # Check for files that would conflict in case-insensitive filesystems
       - id: check-case-conflict
+      # This hook checks toml files for parseable syntax.
+      - id: check-toml
+      # This hook checks yaml files for parseable syntax.
       - id: check-yaml
   - repo: https://github.com/timothycrosley/isort
     rev: 5.6.4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.3.0
+    hooks:
+      - id: check-merge-conflict
+      - id: debug-statements
+      - id: mixed-line-ending
+      - id: check-case-conflict
+      - id: check-yaml
+  - repo: https://github.com/timothycrosley/isort
+    rev: 5.6.4
+    hooks:
+      - id: isort
+  - repo: https://github.com/python/black
+    rev: 20.8b1
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.4
+    hooks:
+      - id: flake8
+        language_version: python3

--- a/README.md
+++ b/README.md
@@ -315,17 +315,23 @@ pip install --editable ".[webpage,dev]"
 ### Commands
 
 Below are some common commands used for development.
-They assume the working directory is set to the repository's root, and the conda environment is activated.
+They assume the working directory is set to the repository's root,
+and the conda environment is activated.
 
 ```shell
 # run the test suite
 pytest
 
-# reformat Python files according to the black style rules (required to pass CI)
-black .
+# install pre-commit git hooks (once per local clone).
+# The pre-commit checks declared in .pre-commit-config.yaml will now
+# run on changed files during git commits.
+pre-commit install
 
-# detect any flake8 linting violations
-flake8
+# run the pre-commit checks (required to pass CI)
+pre-commit run --all-files
+
+# commit despite failing pre-commit checks (will fail CI)
+git commit --no-verify
 
 # regenerate the README codeblocks for --help messages
 python manubot/tests/test_readme.py

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,5 @@
 import pytest
 
-
 markers = dict(
     integration="marks integration tests that cover large portions of the codebase and their interactions",
     appveyor="marks tests where execution on AppVeyor provides additional coverage beyond GitHub Actions",
@@ -62,8 +61,9 @@ def cache_path():
 
 
 def start_caching(hours: int):
-    from datetime import timedelta
     import logging
+    from datetime import timedelta
+
     from requests_cache import install_cache
 
     ttl = timedelta(hours=hours)

--- a/manubot/cite/arxiv.py
+++ b/manubot/cite/arxiv.py
@@ -4,9 +4,10 @@ import xml.etree.ElementTree
 
 import requests
 
+from manubot.util import get_manubot_user_agent
+
 from .csl_item import CSL_Item
 from .handlers import Handler
-from manubot.util import get_manubot_user_agent
 
 
 class Handler_arXiv(Handler):

--- a/manubot/cite/citations.py
+++ b/manubot/cite/citations.py
@@ -159,8 +159,8 @@ class Citations:
 
     @property
     def citekeys_tsv(self) -> str:
-        import io
         import csv
+        import io
 
         fields = ["input_id", "dealiased_id", "standard_id", "short_id"]
         output = io.StringIO()

--- a/manubot/cite/cite_command.py
+++ b/manubot/cite/cite_command.py
@@ -5,9 +5,9 @@ import pathlib
 import subprocess
 import sys
 
+from manubot.cite.citations import Citations
 from manubot.pandoc.util import get_pandoc_info
 from manubot.util import shlex_join
-from manubot.cite.citations import Citations
 
 # For manubot cite, infer --format from --output filename extensions
 extension_to_format = {

--- a/manubot/cite/citekey.py
+++ b/manubot/cite/citekey.py
@@ -212,6 +212,7 @@ def shorten_citekey(standard_citekey: str) -> str:
     citekeys consist of characters in the following ranges: 0-9, a-z and A-Z.
     """
     import hashlib
+
     import base62
 
     assert not standard_citekey.startswith("@")
@@ -264,7 +265,7 @@ def url_to_citekey(url: str) -> str:
     For supported sources, convert from url citekey to an alternative source like doi.
     If citekeys fail inspection, revert alternative sources to URLs.
     """
-    from urllib.parse import urlparse, unquote
+    from urllib.parse import unquote, urlparse
 
     citekey = None
     parsed_url = urlparse(url)

--- a/manubot/cite/curie/__init__.py
+++ b/manubot/cite/curie/__init__.py
@@ -10,8 +10,7 @@ python manubot/cite/curie/__init__.py
 # if namespaces.json has changed, the following test will likely fail:
 pytest manubot/cite/tests/test_handlers.py::test_prefix_to_handler
 # copy captured stdout from failed test_prefix_to_handler to
-# manubot.cite.handlers.prefix_to_handler. Then reformat file:
-black manubot/cite/handlers.py
+# manubot.cite.handlers.prefix_to_handler. Pre-commit hook will reformat file.
 ```
 
 References:

--- a/manubot/cite/doi.py
+++ b/manubot/cite/doi.py
@@ -2,11 +2,12 @@ import json
 import logging
 import urllib.parse
 import urllib.request
-from typing import Optional, Callable, Any
+from typing import Any, Callable, Optional
 
 import requests
 
 from manubot.util import get_manubot_user_agent
+
 from .handlers import Handler
 from .pubmed import get_pubmed_ids_for_doi
 

--- a/manubot/cite/handlers.py
+++ b/manubot/cite/handlers.py
@@ -2,9 +2,10 @@ import abc
 import dataclasses
 import functools
 import re
-from typing import Optional, Dict, Pattern, Tuple, Any
+from typing import Any, Dict, Optional, Pattern, Tuple
 
 from manubot.util import import_function
+
 from .citekey import CiteKey
 
 """

--- a/manubot/cite/isbn.py
+++ b/manubot/cite/isbn.py
@@ -69,6 +69,7 @@ def get_isbn_csl_item_citoid(isbn: str):
     https://en.wikipedia.org/api/rest_v1/#!/Citation/getCitation
     """
     import requests
+
     from manubot.util import get_manubot_user_agent
 
     headers = {"User-Agent": get_manubot_user_agent()}

--- a/manubot/cite/pubmed.py
+++ b/manubot/cite/pubmed.py
@@ -2,15 +2,16 @@ import functools
 import json
 import logging
 import os
-from xml.etree import ElementTree
-from typing import List, Optional, Dict, Any, Union, TYPE_CHECKING
 import warnings
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from xml.etree import ElementTree
 
 import requests
 
+from manubot.util import get_manubot_user_agent
+
 from .citekey import CiteKey
 from .handlers import Handler
-from manubot.util import get_manubot_user_agent
 
 
 class Handler_PubMed(Handler):

--- a/manubot/cite/tests/test_citations.py
+++ b/manubot/cite/tests/test_citations.py
@@ -1,4 +1,5 @@
 import pathlib
+
 import pytest
 
 from manubot.cite.citations import Citations

--- a/manubot/cite/tests/test_cite_command.py
+++ b/manubot/cite/tests/test_cite_command.py
@@ -6,8 +6,8 @@ import subprocess
 import pytest
 
 from manubot.cite.csl_item import CSL_Item
-from manubot.util import shlex_join
 from manubot.pandoc.util import get_pandoc_version
+from manubot.util import shlex_join
 
 data_dir = pathlib.Path(__file__).parent.joinpath("cite-command-rendered")
 

--- a/manubot/cite/tests/test_citekey.py
+++ b/manubot/cite/tests/test_citekey.py
@@ -1,11 +1,7 @@
 """Tests rest of functions in manubot.cite, not covered by test_citekey_api.py."""
 import pytest
 
-from manubot.cite.citekey import (
-    CiteKey,
-    shorten_citekey,
-    url_to_citekey,
-)
+from manubot.cite.citekey import CiteKey, shorten_citekey, url_to_citekey
 
 
 @pytest.mark.parametrize(

--- a/manubot/cite/tests/test_csl_item.py
+++ b/manubot/cite/tests/test_csl_item.py
@@ -6,8 +6,8 @@ import pytest
 from ..csl_item import (
     CSL_Item,
     assert_csl_item_type,
-    date_to_date_parts,
     date_parts_to_string,
+    date_to_date_parts,
 )
 
 

--- a/manubot/cite/tests/test_curie.py
+++ b/manubot/cite/tests/test_curie.py
@@ -1,6 +1,5 @@
 import pytest
 
-
 from ..curie import curie_to_url, get_namespaces, get_prefix_to_namespace
 
 

--- a/manubot/cite/tests/test_doi.py
+++ b/manubot/cite/tests/test_doi.py
@@ -3,8 +3,8 @@ import pytest
 from manubot.cite.doi import (
     expand_short_doi,
     get_doi_csl_item,
-    get_doi_csl_item_zotero,
     get_doi_csl_item_crosscite,
+    get_doi_csl_item_zotero,
 )
 
 

--- a/manubot/cite/tests/test_handlers.py
+++ b/manubot/cite/tests/test_handlers.py
@@ -1,6 +1,6 @@
-from ..handlers import _generate_prefix_to_handler, prefix_to_handler
-
 import pytest
+
+from ..handlers import _generate_prefix_to_handler, prefix_to_handler
 
 
 def test_prefix_to_handler():

--- a/manubot/cite/tests/test_unpaywall.py
+++ b/manubot/cite/tests/test_unpaywall.py
@@ -1,4 +1,4 @@
-from ..unpaywall import Unpaywall, Unpaywall_DOI, Unpaywall_arXiv
+from ..unpaywall import Unpaywall, Unpaywall_arXiv, Unpaywall_DOI
 
 
 def test_unpaywall_doi():

--- a/manubot/cite/tests/test_zotero.py
+++ b/manubot/cite/tests/test_zotero.py
@@ -1,6 +1,6 @@
 import pytest
 
-from manubot.cite.zotero import web_query, search_query, export_as_csl
+from manubot.cite.zotero import export_as_csl, search_query, web_query
 
 
 def test_web_query():

--- a/manubot/cite/url.py
+++ b/manubot/cite/url.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import re
-from typing import Dict, Any
+from typing import Any, Dict
 
 from .handlers import Handler
 
@@ -77,6 +77,7 @@ def get_url_csl_item_greycite(url: str) -> CSLItem:
     https://git.io/v9N2C
     """
     import requests
+
     from manubot.util import get_manubot_user_agent
 
     headers = {

--- a/manubot/cite/wikidata.py
+++ b/manubot/cite/wikidata.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any, Dict
 
 from .handlers import Handler
 

--- a/manubot/cite/zotero.py
+++ b/manubot/cite/zotero.py
@@ -9,7 +9,7 @@ https://github.com/manubot/manubot/issues/82.
 
 import json
 import logging
-from typing import Dict, Any, List
+from typing import Any, Dict, List
 
 import requests
 

--- a/manubot/pandoc/cite_filter.py
+++ b/manubot/pandoc/cite_filter.py
@@ -258,7 +258,7 @@ def process_citations(doc: pf.Doc) -> None:
 
 
 def main() -> None:
-    from manubot.command import setup_logging_and_errors, exit_if_error_handler_fired
+    from manubot.command import exit_if_error_handler_fired, setup_logging_and_errors
 
     diagnostics = setup_logging_and_errors()
     args = parse_args()

--- a/manubot/pandoc/util.py
+++ b/manubot/pandoc/util.py
@@ -1,7 +1,7 @@
+import functools
 import logging
 import shutil
 import subprocess
-import functools
 from typing import Any, Dict, Tuple
 
 

--- a/manubot/process/ci.py
+++ b/manubot/process/ci.py
@@ -1,5 +1,5 @@
-import os
 import logging
+import os
 
 supported_providers = ["github", "travis", "appveyor"]
 

--- a/manubot/process/metadata.py
+++ b/manubot/process/metadata.py
@@ -130,6 +130,7 @@ def get_manuscript_urls(html_url: Optional[str] = None) -> dict:
     Note the trailing `/` in `html_url`, which is required for proper functioning.
     """
     import requests
+
     from .ci import get_continuous_integration_parameters
 
     urls = dict()

--- a/manubot/process/tests/manuscripts/citation-rendering/content/generate-csl-json-combinations.py
+++ b/manubot/process/tests/manuscripts/citation-rendering/content/generate-csl-json-combinations.py
@@ -2,8 +2,8 @@
 Create CSL JSON metadata with combinations of fields for testing
 """
 
-import pathlib
 import json
+import pathlib
 
 content_dir = pathlib.Path(__file__).parent
 

--- a/manubot/process/tests/test_metadata.py
+++ b/manubot/process/tests/test_metadata.py
@@ -2,9 +2,8 @@ import copy
 
 import pytest
 
-
-from ..metadata import get_header_includes, get_thumbnail_url, get_manuscript_urls
 from ..ci import get_continuous_integration_parameters
+from ..metadata import get_header_includes, get_manuscript_urls, get_thumbnail_url
 
 
 def test_get_header_includes_description_abstract():

--- a/manubot/process/util.py
+++ b/manubot/process/util.py
@@ -7,19 +7,15 @@ from typing import List, Optional
 
 import jinja2
 
-from manubot.util import read_serialized_data, read_serialized_dict, get_configured_yaml
 from manubot.process.ci import get_continuous_integration_parameters
+from manubot.process.manuscript import datetime_now, get_manuscript_stats, get_text
 from manubot.process.metadata import (
     get_header_includes,
-    get_thumbnail_url,
     get_manuscript_urls,
     get_software_versions,
+    get_thumbnail_url,
 )
-from manubot.process.manuscript import (
-    datetime_now,
-    get_manuscript_stats,
-    get_text,
-)
+from manubot.util import get_configured_yaml, read_serialized_data, read_serialized_dict
 
 
 def read_variable_files(paths: List[str], variables: Optional[dict] = None) -> dict:

--- a/manubot/tests/test_util.py
+++ b/manubot/tests/test_util.py
@@ -1,6 +1,6 @@
-import manubot.util
-
 import pytest
+
+import manubot.util
 
 
 def test_shlex_join():

--- a/manubot/util.py
+++ b/manubot/util.py
@@ -167,6 +167,7 @@ def get_configured_yaml() -> ModuleType:
     The representers are only applied to yaml.dump, not yaml.safe_dump.
     """
     import yaml
+
     from manubot.cite.csl_item import CSL_Item
 
     yaml.add_representer(str, _yaml_str_representer)

--- a/setup.cfg
+++ b/setup.cfg
@@ -95,8 +95,6 @@ select = B,C,E,F,W,T4,B9
 
 [isort]
 profile = black
-default_section = THIRDPARTY
-known_third_party = pytest
 multi_line_output = 3
 include_trailing_comma = True
 force_grid_wrap = 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,7 @@ dev =
     exrex
     flake8
     portray
+    pre-commit
     pytest >= 3.3.0
     yamllint
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,9 +62,7 @@ install_requires =
 webpage =
     opentimestamps-client
 dev =
-    black
     exrex
-    flake8
     portray
     pre-commit
     pytest >= 3.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -92,3 +92,13 @@ max-line-length = 80
 # TODO: refactor to reduce max-complexity to 18
 max-complexity = 19
 select = B,C,E,F,W,T4,B9
+
+[isort]
+profile = black
+default_section = THIRDPARTY
+known_third_party = pytest
+multi_line_output = 3
+include_trailing_comma = True
+force_grid_wrap = 0
+use_parentheses = True
+line_length = 88


### PR DESCRIPTION
Use pre-commit for checks. Previously, CI would fail if there were style or format errors (via black or flake8), but these errors would not be automatically fixed nor detected at commit time.

Added isort to apply a standard order to all import statements.

Pre-commit is a python package, that will now be a dev dependency. Removed black and flake8 from dev dependencies because these versions are handled separately in  `.pre-commit-config.yaml`.

Users must run `pre-commit install` in the repo for these checks to be active.