### PR TITLE
fix exclusion of tests in wheel distribution

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -71,6 +71,7 @@ dev =
 [options.packages.find]
 exclude =
     tests
+    *.tests
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
We included the following to exclude tests from our distributions:

https://github.com/manubot/manubot/blob/0c2e5b28809acd7c9ca76152146ddc24345d0781/setup.cfg#L71-L73

But that doesn't actually work. It only works to exclude a top-level `tests` directory from being detected by `find_packages`.