### PR TITLE
cite requests: better error messages

### DIFF
--- a/manubot/cite/arxiv.py
+++ b/manubot/cite/arxiv.py
@@ -80,6 +80,7 @@ def get_arxiv_csl_item(arxiv_id: str):
 def query_arxiv_api(url, params):
     headers = {"User-Agent": get_manubot_user_agent()}
     response = requests.get(url, params, headers=headers)
+    response.raise_for_status()
     xml_tree = xml.etree.ElementTree.fromstring(response.text)
     return xml_tree
 

--- a/manubot/cite/unpaywall.py
+++ b/manubot/cite/unpaywall.py
@@ -106,6 +106,7 @@ class Unpaywall_DOI(Unpaywall):
         url = f"https://api.unpaywall.org/v2/{self.doi}"
         params = {"email": contact_email}
         response = requests.get(url, params=params)
+        response.raise_for_status()
         self.results = response.json()
         self.oa_locations = [
             Unpaywall_Location(location)

--- a/manubot/cite/url.py
+++ b/manubot/cite/url.py
@@ -87,6 +87,7 @@ def get_url_csl_item_greycite(url: str) -> CSLItem:
     response = requests.get(
         "http://greycite.knowledgeblog.org/json", params={"uri": url}, headers=headers
     )
+    response.raise_for_status()
     # Some Greycite responses were valid JSON besides for an error appended
     # like "<p>*** Date set from uri<p>" or "<p>*** fetch error : 404<p>".
     pattern = re.compile(r"<p>\*\*\*.*<p>")


### PR DESCRIPTION
closes https://github.com/manubot/manubot/issues/278

use response.raise_for_status() to raise an exception with an error message like:
> 503 Server Error: Retry after specified interval for url: https://export.arxiv.org/oai2?verb=GetRecord&metadataPrefix=arXiv&identifier=oai%3AarXiv.org%3A1607.00653

This message contains the bad status code and the URL.