### PR TITLE
Add command-line argument to skip adding the rootstock git remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ usage: manubot process [-h] --content-directory CONTENT_DIRECTORY
                        --output-directory OUTPUT_DIRECTORY
                        [--template-variables-path TEMPLATE_VARIABLES_PATH]
                        --skip-citations [--cache-directory CACHE_DIRECTORY]
-                       [--clear-requests-cache]
+                       [--clear-requests-cache] [--skip-remote]
                        [--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
 
 Process manuscript content to create outputs for Pandoc consumption. Performs
@@ -145,6 +145,8 @@ optional arguments:
                         Custom cache directory. If not specified, caches to
                         output-directory.
   --clear-requests-cache
+  --skip-remote         Do not add the rootstock repository to the local git
+                        repository remotes.
   --log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}
                         Set the logging level for stderr logging
 ```

--- a/manubot/command.py
+++ b/manubot/command.py
@@ -89,6 +89,11 @@ def add_subparser_process(subparsers):
         help="Custom cache directory. If not specified, caches to output-directory.",
     )
     parser.add_argument("--clear-requests-cache", action="store_true")
+    parser.add_argument(
+        "--skip-remote",
+        action="store_true",
+        help="Do not add the rootstock repository to the local git repository remotes.",
+    )
     parser.set_defaults(function="manubot.process.process_command.cli_process")
 
 

--- a/manubot/process/metadata.py
+++ b/manubot/process/metadata.py
@@ -160,7 +160,7 @@ def get_manuscript_urls(html_url: Optional[str] = None) -> dict:
     return urls
 
 
-def get_software_versions() -> dict:
+def get_software_versions(rootstock: bool = True) -> dict:
     """
     Return a dictionary of software versions for softwares components:
 
@@ -169,12 +169,15 @@ def get_software_versions() -> dict:
       included in the manuscript repository.
 
     Values whose detection fails are set to None.
+
+    The `rootstock` parameter controls whether to fetch the rootstock commit id.
+    The rootstock git remote will be added to the local git repository if true.
     """
     from manubot import __version__ as manubot_version
 
     return {
         "manubot_version": manubot_version,
-        "rootstock_commit": get_rootstock_commit(),
+        "rootstock_commit": get_rootstock_commit() if rootstock else None,
     }
 
 

--- a/manubot/process/util.py
+++ b/manubot/process/util.py
@@ -214,7 +214,7 @@ def load_variables(args) -> dict:
     variables["manubot"].update(get_manuscript_urls(metadata.pop("html_url", None)))
 
     # Add software versions
-    variables["manubot"].update(get_software_versions())
+    variables["manubot"].update(get_software_versions(rootstock=not args.skip_remote))
 
     # Add thumbnail URL if present
     thumbnail_url = get_thumbnail_url(metadata.pop("thumbnail", None))


### PR DESCRIPTION
closes https://github.com/manubot/manubot/issues/290

Addresses https://github.com/manubot/manubot/issues/290 and related issues by adding the `--skip-remote` command-line flag to `manubot process` that will skip over fetching the rootstock commit ID and therefore not adding the rootstock git remote to the local git repository.

This makes life a bit easier for those using manubot in a non-standard way, such as outside the rootstock repository.

Implementation is up for discussion but I've tested this one and it works locally.