### PR TITLE
gh actions job_id: use GITHUB_RUN_ID

### DIFF
--- a/manubot/process/ci.py
+++ b/manubot/process/ci.py
@@ -35,7 +35,7 @@ def get_continuous_integration_parameters():
         # https://git.io/JvUf7
         repo_slug = os.environ["GITHUB_REPOSITORY"]
         repo_owner, repo_name = repo_slug.split("/")
-        action_id = os.environ["GITHUB_ACTION"]
+        run_id = os.environ["GITHUB_RUN_ID"]
         # GITHUB_SHA for pull_request event: Last merge commit on the GITHUB_REF branch
         # GITHUB_SHA for push event: Commit pushed, unless deleting a branch (when it's the default branch)
         # https://git.io/JvUfd
@@ -48,7 +48,7 @@ def get_continuous_integration_parameters():
             "commit": github_sha,
             "triggering_commit": os.getenv("GITHUB_PULL_REQUEST_SHA") or github_sha,
             "build_url": f"https://github.com/{repo_slug}/commit/{github_sha}/checks",
-            "job_url": f"https://github.com/{repo_slug}/runs/{action_id}",
+            "job_url": f"https://github.com/{repo_slug}/actions/runs/{run_id}",
         }
         return ci_params
 

--- a/manubot/process/tests/test_ci.py
+++ b/manubot/process/tests/test_ci.py
@@ -23,7 +23,9 @@ def test_get_continuous_integration_parameters_github():
     assert info["commit"]
     assert info["triggering_commit"]
     assert info["build_url"].startswith("https://github.com/manubot/manubot/commit/")
-    assert info["job_url"].startswith("https://github.com/manubot/manubot/runs/")
+    assert info["job_url"].startswith(
+        "https://github.com/manubot/manubot/actions/runs/"
+    )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
instead of GITHUB_ACTION which had values like __run_4 on
workflow_dispatch, and appears to have produced broken URLs in the
past.

refs https://github.com/manubot/rootstock/pull/436#issuecomment-905837795