### PR TITLE
Refactor CURIE handling with Bioregistry package

### DIFF
--- a/manubot/cite/curie/__init__.py
+++ b/manubot/cite/curie/__init__.py
@@ -30,6 +30,7 @@ References:
 - [On the road to robust data citation](https://doi.org/10.1038/sdata.2018.95)
 - [Uniform Resolution of Compact Identifiers for Biomedical Data](https://doi.org/10.1038/sdata.2018.29)
 """
+
 import dataclasses
 import functools
 import json
@@ -72,7 +73,7 @@ class Handler_CURIE(Handler):
         try:
             self.resource = get_prefix_to_resource()[self.prefix_lower]
         except KeyError:
-tgith            raise ValueError(f"Unrecognized CURIE prefix {self.prefix_lower}")
+            raise ValueError(f"Unrecognized CURIE prefix {self.prefix_lower}")
         self.standard_prefix = (
             self.resource.get("preferred_prefix") or self.resource["prefix"]
         )

--- a/manubot/cite/curie/__init__.py
+++ b/manubot/cite/curie/__init__.py
@@ -37,6 +37,8 @@ import pathlib
 import re
 import typing
 
+import bioregistry
+
 from manubot.cite.citekey import CiteKey
 from manubot.cite.handlers import Handler
 
@@ -70,7 +72,7 @@ class Handler_CURIE(Handler):
         try:
             self.resource = get_prefix_to_resource()[self.prefix_lower]
         except KeyError:
-            raise ValueError(f"Unrecognized CURIE prefix {self.prefix_lower}")
+tgith            raise ValueError(f"Unrecognized CURIE prefix {self.prefix_lower}")
         self.standard_prefix = (
             self.resource.get("preferred_prefix") or self.resource["prefix"]
         )

--- a/manubot/cite/curie/__init__.py
+++ b/manubot/cite/curie/__init__.py
@@ -79,7 +79,6 @@ class Handler_CURIE(Handler):
         self.resource = manager.get_resource(self.prefix_lower)
         if self.resource is None:
             raise ValueError(f"Unrecognized CURIE prefix {self.prefix_lower}")
-        self.standard_prefix = self.resource.get_preferred_prefix()
 
     def get_csl_item(self, citekey: CiteKey):
         from ..url import get_url_csl_item

--- a/manubot/cite/curie/__init__.py
+++ b/manubot/cite/curie/__init__.py
@@ -152,6 +152,8 @@ def curie_to_url(curie: str) -> str:
     `curie` should be in `prefix:accession` format
     """
     prefix, accession = manager.parse_curie(curie)
+    if prefix is None or accession is None:
+        raise ValueError(f"Could not parse {curie}")
     handler = Handler_CURIE(prefix.lower())
     return handler.get_url(accession)
 

--- a/manubot/cite/curie/__init__.py
+++ b/manubot/cite/curie/__init__.py
@@ -130,7 +130,7 @@ def _download_bioregistry() -> None:
             *(x.lower() for x in resource.pop("synonyms", [])),
         }
         # remove invalid prefixes as per https://github.com/manubot/manubot/pull/306#discussion_r744125504
-        resource["all_prefixes"] = sorted(
+        resource["synonyms"] = sorted(
             filter(valid_prefix_pattern.fullmatch, all_prefixes)
         )
         registry.append(resource)

--- a/manubot/cite/curie/bioregistry.json
+++ b/manubot/cite/curie/bioregistry.json
@@ -6,7 +6,7 @@
     "preferred_prefix": "3dmet",
     "uri_format": "http://www.3dmet.dna.affrc.go.jp/cgi/show_data.php?acc=$1",
     "prefix": "3dmet",
-    "all_prefixes": [
+    "synonyms": [
       "3dmet"
     ]
   },
@@ -17,7 +17,7 @@
     "preferred_prefix": "4dn.biosource",
     "uri_format": "https://data.4dnucleome.org/biosources/$1",
     "prefix": "4dn.biosource",
-    "all_prefixes": [
+    "synonyms": [
       "4dn",
       "4dn.biosource"
     ]
@@ -28,7 +28,7 @@
     "preferred_prefix": "4dn.replicate",
     "uri_format": "https://data.4dnucleome.org/experiment-set-replicates/$1",
     "prefix": "4dn.replicate",
-    "all_prefixes": [
+    "synonyms": [
       "4dn.replicate"
     ]
   },
@@ -38,7 +38,7 @@
     "preferred_prefix": "AAO",
     "uri_format": "http://purl.obolibrary.org/obo/AAO_$1",
     "prefix": "aao",
-    "all_prefixes": [
+    "synonyms": [
       "aao"
     ]
   },
@@ -48,7 +48,7 @@
     "preferred_prefix": "abcd",
     "uri_format": "https://web.expasy.org/abcd/ABCD_$1",
     "prefix": "abcd",
-    "all_prefixes": [
+    "synonyms": [
       "abcd"
     ]
   },
@@ -59,7 +59,7 @@
     "preferred_prefix": "abs",
     "uri_format": "http://genome.crg.es/datasets/abs2005/entries/$1.html",
     "prefix": "abs",
-    "all_prefixes": [
+    "synonyms": [
       "abs"
     ]
   },
@@ -69,7 +69,7 @@
     "preferred_prefix": "ac",
     "uri_format": "http://www.w3.org/ns/activitystreams#$1",
     "prefix": "ac",
-    "all_prefixes": [
+    "synonyms": [
       "ac"
     ]
   },
@@ -80,7 +80,7 @@
     "preferred_prefix": "aceview.worm",
     "uri_format": "https://www.ncbi.nlm.nih.gov/IEB/Research/Acembly/av.cgi?db=worm&c=Gene&l=$1",
     "prefix": "aceview.worm",
-    "all_prefixes": [
+    "synonyms": [
       "aceview.worm"
     ]
   },
@@ -91,7 +91,7 @@
     "preferred_prefix": "addgene",
     "uri_format": "http://addgene.org/$1",
     "prefix": "addgene",
-    "all_prefixes": [
+    "synonyms": [
       "addgene"
     ]
   },
@@ -103,7 +103,7 @@
     "preferred_prefix": "ADW",
     "uri_format": "https://animaldiversity.org/accounts/$1",
     "prefix": "adw",
-    "all_prefixes": [
+    "synonyms": [
       "adw"
     ]
   },
@@ -114,7 +114,7 @@
     "preferred_prefix": "AEO",
     "uri_format": "http://purl.obolibrary.org/obo/AEO_$1",
     "prefix": "aeo",
-    "all_prefixes": [
+    "synonyms": [
       "aeo",
       "aeo_retired"
     ]
@@ -126,7 +126,7 @@
     "preferred_prefix": "AERO",
     "uri_format": "http://purl.obolibrary.org/obo/AERO_$1",
     "prefix": "aero",
-    "all_prefixes": [
+    "synonyms": [
       "aero"
     ]
   },
@@ -137,7 +137,7 @@
     "preferred_prefix": "affy.probeset",
     "uri_format": "https://www.affymetrix.com/LinkServlet?probeset=$1",
     "prefix": "affy.probeset",
-    "all_prefixes": [
+    "synonyms": [
       "affy.probeset"
     ]
   },
@@ -148,7 +148,7 @@
     "preferred_prefix": "aftol.taxonomy",
     "uri_format": "http://wasabi.lutzonilab.net/pub/displayTaxonInfo?aftol_id=$1",
     "prefix": "aftol.taxonomy",
-    "all_prefixes": [
+    "synonyms": [
       "aftol.taxonomy"
     ]
   },
@@ -159,7 +159,7 @@
     "preferred_prefix": "agricola",
     "uri_format": "http://ddr.nal.usda.gov/dspace/handle/10113/$1",
     "prefix": "agricola",
-    "all_prefixes": [
+    "synonyms": [
       "agr",
       "agricola",
       "agricola_id"
@@ -171,7 +171,7 @@
     "preferred_prefix": "AGRO",
     "uri_format": "http://purl.obolibrary.org/obo/AGRO_$1",
     "prefix": "agro",
-    "all_prefixes": [
+    "synonyms": [
       "agro"
     ]
   },
@@ -181,7 +181,7 @@
     "preferred_prefix": "AISM",
     "uri_format": "http://purl.obolibrary.org/obo/AISM_$1",
     "prefix": "aism",
-    "all_prefixes": [
+    "synonyms": [
       "aism"
     ]
   },
@@ -192,7 +192,7 @@
     "preferred_prefix": "allergome",
     "uri_format": "http://www.allergome.org/script/dettaglio.php?id_molecule=$1",
     "prefix": "allergome",
-    "all_prefixes": [
+    "synonyms": [
       "allergome"
     ]
   },
@@ -202,7 +202,7 @@
     "preferred_prefix": "alzforum.mutation",
     "uri_format": "https://www.alzforum.org/mutations/$1",
     "prefix": "alzforum.mutation",
-    "all_prefixes": [
+    "synonyms": [
       "alzforum.mutation",
       "alzforum_mut"
     ]
@@ -214,7 +214,7 @@
     "preferred_prefix": "amoebadb",
     "uri_format": "https://amoebadb.org/amoeba/app/record/gene/$1",
     "prefix": "amoebadb",
-    "all_prefixes": [
+    "synonyms": [
       "amoebadb"
     ]
   },
@@ -224,7 +224,7 @@
     "preferred_prefix": "AMPHX",
     "uri_format": "http://purl.obolibrary.org/obo/AMPHX_$1",
     "prefix": "amphx",
-    "all_prefixes": [
+    "synonyms": [
       "amphx"
     ]
   },
@@ -235,7 +235,7 @@
     "preferred_prefix": "antibodyregistry",
     "uri_format": "http://antibodyregistry.org/AB_$1",
     "prefix": "antibodyregistry",
-    "all_prefixes": [
+    "synonyms": [
       "antibodyregistry"
     ]
   },
@@ -246,7 +246,7 @@
     "preferred_prefix": "antweb",
     "uri_format": "http://www.antweb.org/specimen.do?name=$1",
     "prefix": "antweb",
-    "all_prefixes": [
+    "synonyms": [
       "antweb"
     ]
   },
@@ -257,7 +257,7 @@
     "preferred_prefix": "aop",
     "uri_format": "https://aopwiki.org/aops/$1",
     "prefix": "aop",
-    "all_prefixes": [
+    "synonyms": [
       "aop"
     ]
   },
@@ -268,7 +268,7 @@
     "preferred_prefix": "aop.events",
     "uri_format": "https://aopwiki.org/events/$1",
     "prefix": "aop.events",
-    "all_prefixes": [
+    "synonyms": [
       "aop.events"
     ]
   },
@@ -279,7 +279,7 @@
     "preferred_prefix": "aop.relationships",
     "uri_format": "https://aopwiki.org/relationships/$1",
     "prefix": "aop.relationships",
-    "all_prefixes": [
+    "synonyms": [
       "aop.relationships"
     ]
   },
@@ -290,7 +290,7 @@
     "preferred_prefix": "aop.stressor",
     "uri_format": "https://aopwiki.org/stressors/$1",
     "prefix": "aop.stressor",
-    "all_prefixes": [
+    "synonyms": [
       "aop.stressor"
     ]
   },
@@ -301,7 +301,7 @@
     "preferred_prefix": "apd",
     "uri_format": "http://aps.unmc.edu/AP/database/query_output.php?ID=$1",
     "prefix": "apd",
-    "all_prefixes": [
+    "synonyms": [
       "apd"
     ]
   },
@@ -312,7 +312,7 @@
     "preferred_prefix": "aphidbase.transcript",
     "uri_format": "http://bipaa.genouest.org/apps/grs-2.3/grs?reportID=aphidbase_transcript_report&objectID=$1",
     "prefix": "aphidbase.transcript",
-    "all_prefixes": [
+    "synonyms": [
       "aphidbase.transcript"
     ]
   },
@@ -323,7 +323,7 @@
     "preferred_prefix": "apid.interactions",
     "uri_format": "http://cicblade.dep.usal.es:8080/APID/Interactions.action?protein=$1",
     "prefix": "apid.interactions",
-    "all_prefixes": [
+    "synonyms": [
       "apid.interactions"
     ]
   },
@@ -335,7 +335,7 @@
     "preferred_prefix": "APO",
     "uri_format": "https://www.yeastgenome.org/observable/APO:$1",
     "prefix": "apo",
-    "all_prefixes": [
+    "synonyms": [
       "apo",
       "ypo"
     ]
@@ -346,7 +346,7 @@
     "preferred_prefix": "APOLLO_SV",
     "uri_format": "http://purl.obolibrary.org/obo/APOLLO_SV_$1",
     "prefix": "apollosv",
-    "all_prefixes": [
+    "synonyms": [
       "apollosv"
     ]
   },
@@ -357,7 +357,7 @@
     "preferred_prefix": "arachnoserver",
     "uri_format": "http://www.arachnoserver.org/toxincard.html?id=$1",
     "prefix": "arachnoserver",
-    "all_prefixes": [
+    "synonyms": [
       "arachnoserver"
     ]
   },
@@ -367,7 +367,7 @@
     "preferred_prefix": "araport",
     "uri_format": "https://www.arabidopsis.org/servlets/TairObject?type=locus&name=$1",
     "prefix": "araport",
-    "all_prefixes": [
+    "synonyms": [
       "araport"
     ]
   },
@@ -378,7 +378,7 @@
     "preferred_prefix": "ardb",
     "uri_format": "http://ardb.cbcb.umd.edu/cgi/search.cgi?db=L&amp;field=ni&amp;term=$1",
     "prefix": "ardb",
-    "all_prefixes": [
+    "synonyms": [
       "ardb"
     ]
   },
@@ -389,7 +389,7 @@
     "preferred_prefix": "ark",
     "uri_format": "http://n2t.net/ark:$1",
     "prefix": "ark",
-    "all_prefixes": [
+    "synonyms": [
       "ark"
     ]
   },
@@ -400,7 +400,7 @@
     "preferred_prefix": "ARO",
     "uri_format": "http://purl.obolibrary.org/obo/ARO_$1",
     "prefix": "aro",
-    "all_prefixes": [
+    "synonyms": [
       "aro"
     ]
   },
@@ -411,7 +411,7 @@
     "preferred_prefix": "arrayexpress",
     "uri_format": "https://www.ebi.ac.uk/arrayexpress/experiments/$1",
     "prefix": "arrayexpress",
-    "all_prefixes": [
+    "synonyms": [
       "arrayexpress"
     ]
   },
@@ -422,7 +422,7 @@
     "preferred_prefix": "arrayexpress.platform",
     "uri_format": "https://www.ebi.ac.uk/arrayexpress/arrays/$1",
     "prefix": "arrayexpress.platform",
-    "all_prefixes": [
+    "synonyms": [
       "arrayexpress.platform"
     ]
   },
@@ -433,7 +433,7 @@
     "preferred_prefix": "arraymap",
     "uri_format": "https://www.arraymap.org/pgx:$1",
     "prefix": "arraymap",
-    "all_prefixes": [
+    "synonyms": [
       "arraymap"
     ]
   },
@@ -444,7 +444,7 @@
     "preferred_prefix": "arxiv",
     "uri_format": "https://arxiv.org/abs/$1",
     "prefix": "arxiv",
-    "all_prefixes": [
+    "synonyms": [
       "arxiv"
     ]
   },
@@ -455,7 +455,7 @@
     "preferred_prefix": "asap",
     "uri_format": "http://asap.ahabs.wisc.edu/asap/feature_info.php?LocationID=WIS&FeatureID=$1",
     "prefix": "asap",
-    "all_prefixes": [
+    "synonyms": [
       "asap"
     ]
   },
@@ -466,7 +466,7 @@
     "preferred_prefix": "ascl",
     "uri_format": "http://ascl.net/$1",
     "prefix": "ascl",
-    "all_prefixes": [
+    "synonyms": [
       "ascl"
     ]
   },
@@ -477,7 +477,7 @@
     "preferred_prefix": "asin",
     "uri_format": "https://amzn.com/$1",
     "prefix": "asin",
-    "all_prefixes": [
+    "synonyms": [
       "asin"
     ]
   },
@@ -488,7 +488,7 @@
     "preferred_prefix": "aspgd.locus",
     "uri_format": "http://www.aspergillusgenome.org/cgi-bin/locus.pl?dbid=$1",
     "prefix": "aspgd.locus",
-    "all_prefixes": [
+    "synonyms": [
       "aspgd.locus"
     ]
   },
@@ -499,7 +499,7 @@
     "preferred_prefix": "aspgd.protein",
     "uri_format": "http://www.aspergillusgenome.org/cgi-bin/protein/proteinPage.pl?dbid=$1",
     "prefix": "aspgd.protein",
-    "all_prefixes": [
+    "synonyms": [
       "aspgd.protein"
     ]
   },
@@ -510,7 +510,7 @@
     "preferred_prefix": "assembly",
     "uri_format": "https://www.ncbi.nlm.nih.gov/assembly/$1",
     "prefix": "assembly",
-    "all_prefixes": [
+    "synonyms": [
       "assembly"
     ]
   },
@@ -521,7 +521,7 @@
     "preferred_prefix": "atc",
     "uri_format": "http://www.whocc.no/atc_ddd_index/?code=$1",
     "prefix": "atc",
-    "all_prefixes": [
+    "synonyms": [
       "atc",
       "atc_code",
       "attc"
@@ -534,7 +534,7 @@
     "preferred_prefix": "atcc",
     "uri_format": "https://www.atcc.org/products/$1",
     "prefix": "atcc",
-    "all_prefixes": [
+    "synonyms": [
       "atcc"
     ]
   },
@@ -545,7 +545,7 @@
     "preferred_prefix": "atcvet",
     "uri_format": "http://www.whocc.no/atcvet/atcvet_index/?code=$1",
     "prefix": "atcvet",
-    "all_prefixes": [
+    "synonyms": [
       "atcvet"
     ]
   },
@@ -556,7 +556,7 @@
     "preferred_prefix": "atfdb.family",
     "uri_format": "http://www.bioguo.org/AnimalTFDB/family.php?fam=$1",
     "prefix": "atfdb.family",
-    "all_prefixes": [
+    "synonyms": [
       "atfdb.family"
     ]
   },
@@ -566,7 +566,7 @@
     "preferred_prefix": "ATO",
     "uri_format": "http://purl.obolibrary.org/obo/ATO_$1",
     "prefix": "ato",
-    "all_prefixes": [
+    "synonyms": [
       "ato"
     ]
   },
@@ -577,7 +577,7 @@
     "preferred_prefix": "autdb",
     "uri_format": "http://autism.mindspec.org/GeneDetail/$1",
     "prefix": "autdb",
-    "all_prefixes": [
+    "synonyms": [
       "autdb"
     ]
   },
@@ -588,7 +588,7 @@
     "preferred_prefix": "bacdive",
     "uri_format": "https://bacdive.dsmz.de/strain/$1",
     "prefix": "bacdive",
-    "all_prefixes": [
+    "synonyms": [
       "bacdive"
     ]
   },
@@ -599,7 +599,7 @@
     "preferred_prefix": "bacmap.biog",
     "uri_format": "http://bacmap.wishartlab.com/organisms/$1",
     "prefix": "bacmap.biog",
-    "all_prefixes": [
+    "synonyms": [
       "bacmap.biog"
     ]
   },
@@ -610,7 +610,7 @@
     "preferred_prefix": "bacmap.map",
     "uri_format": "http://bacmap.wishartlab.com/maps/$1/index.html",
     "prefix": "bacmap.map",
-    "all_prefixes": [
+    "synonyms": [
       "bacmap.map"
     ]
   },
@@ -620,7 +620,7 @@
     "preferred_prefix": "bactibase",
     "uri_format": "http://bactibase.hammamilab.org/$1",
     "prefix": "bactibase",
-    "all_prefixes": [
+    "synonyms": [
       "bactibase"
     ]
   },
@@ -631,7 +631,7 @@
     "preferred_prefix": "bao",
     "uri_format": "http://bioportal.bioontology.org/ontologies/BAO/bao:BAO_$1",
     "prefix": "bao",
-    "all_prefixes": [
+    "synonyms": [
       "bao"
     ]
   },
@@ -641,7 +641,7 @@
     "preferred_prefix": "BCGO",
     "uri_format": "http://purl.obolibrary.org/obo/BCGO_$1",
     "prefix": "bcgo",
-    "all_prefixes": [
+    "synonyms": [
       "bcgo"
     ]
   },
@@ -651,7 +651,7 @@
     "preferred_prefix": "BCO",
     "uri_format": "http://purl.obolibrary.org/obo/BCO_$1",
     "prefix": "bco",
-    "all_prefixes": [
+    "synonyms": [
       "bco"
     ]
   },
@@ -662,7 +662,7 @@
     "preferred_prefix": "bdgp.est",
     "uri_format": "https://www.ncbi.nlm.nih.gov/nucest/$1",
     "prefix": "bdgp.est",
-    "all_prefixes": [
+    "synonyms": [
       "bdgp.est"
     ]
   },
@@ -673,7 +673,7 @@
     "preferred_prefix": "bdgp.insertion",
     "uri_format": "http://flypush.imgen.bcm.tmc.edu/pscreen/details.php?line=$1",
     "prefix": "bdgp.insertion",
-    "all_prefixes": [
+    "synonyms": [
       "bdgp.insertion"
     ]
   },
@@ -684,7 +684,7 @@
     "preferred_prefix": "bdsc",
     "uri_format": "https://bdsc.indiana.edu/stocks/$1",
     "prefix": "bdsc",
-    "all_prefixes": [
+    "synonyms": [
       "bdsc"
     ]
   },
@@ -695,7 +695,7 @@
     "preferred_prefix": "beetlebase",
     "uri_format": "http://beetlebase.org/cgi-bin/gbrowse/BeetleBase3.gff3/?name=$1",
     "prefix": "beetlebase",
-    "all_prefixes": [
+    "synonyms": [
       "beetlebase"
     ]
   },
@@ -706,7 +706,7 @@
     "preferred_prefix": "begdb",
     "uri_format": "http://www.begdb.com/index.php?action=oneMolecule&state=show&id=$1",
     "prefix": "begdb",
-    "all_prefixes": [
+    "synonyms": [
       "begdb"
     ]
   },
@@ -717,7 +717,7 @@
     "preferred_prefix": "BFO",
     "uri_format": "http://purl.obolibrary.org/obo/BFO_$1",
     "prefix": "bfo",
-    "all_prefixes": [
+    "synonyms": [
       "bfo"
     ]
   },
@@ -728,7 +728,7 @@
     "preferred_prefix": "bgee.family",
     "uri_format": "http://bgee.unil.ch/bgee/bgee?page=gene_family&action=family_details&gene_family_id=$1",
     "prefix": "bgee.family",
-    "all_prefixes": [
+    "synonyms": [
       "bgee.family"
     ]
   },
@@ -739,7 +739,7 @@
     "preferred_prefix": "bgee.gene",
     "uri_format": "https://bgee.org/?page=gene&gene_id=$1",
     "prefix": "bgee.gene",
-    "all_prefixes": [
+    "synonyms": [
       "bgee.gene"
     ]
   },
@@ -750,7 +750,7 @@
     "preferred_prefix": "bgee.organ",
     "uri_format": "http://bgee.unil.ch/bgee/bgee?page=anatomy&action=organ_details&organ_children=on&organ_id=$1",
     "prefix": "bgee.organ",
-    "all_prefixes": [
+    "synonyms": [
       "bgee.organ"
     ]
   },
@@ -761,7 +761,7 @@
     "preferred_prefix": "bgee.stage",
     "uri_format": "http://bgee.unil.ch/bgee/bgee?page=anatomy&action=organs&stage_children=on&stage_id=$1",
     "prefix": "bgee.stage",
-    "all_prefixes": [
+    "synonyms": [
       "bgee.stage"
     ]
   },
@@ -772,7 +772,7 @@
     "preferred_prefix": "bigg.compartment",
     "uri_format": "http://bigg.ucsd.edu/compartments/$1",
     "prefix": "bigg.compartment",
-    "all_prefixes": [
+    "synonyms": [
       "bigg.compartment"
     ]
   },
@@ -783,7 +783,7 @@
     "preferred_prefix": "bigg.metabolite",
     "uri_format": "http://bigg.ucsd.edu/models/universal/metabolites/$1",
     "prefix": "bigg.metabolite",
-    "all_prefixes": [
+    "synonyms": [
       "bigg.metabolite"
     ]
   },
@@ -794,7 +794,7 @@
     "preferred_prefix": "bigg.model",
     "uri_format": "http://bigg.ucsd.edu/models/$1",
     "prefix": "bigg.model",
-    "all_prefixes": [
+    "synonyms": [
       "bigg.model"
     ]
   },
@@ -805,7 +805,7 @@
     "preferred_prefix": "bigg.reaction",
     "uri_format": "http://bigg.ucsd.edu/models/universal/reactions/$1",
     "prefix": "bigg.reaction",
-    "all_prefixes": [
+    "synonyms": [
       "bigg.reaction"
     ]
   },
@@ -815,7 +815,7 @@
     "preferred_prefix": "BILA",
     "uri_format": "http://purl.obolibrary.org/obo/BILA_$1",
     "prefix": "bila",
-    "all_prefixes": [
+    "synonyms": [
       "bila"
     ]
   },
@@ -826,7 +826,7 @@
     "preferred_prefix": "bindingdb",
     "uri_format": "http://www.bindingdb.org/compact/$1",
     "prefix": "bindingdb",
-    "all_prefixes": [
+    "synonyms": [
       "bindingdb"
     ]
   },
@@ -837,7 +837,7 @@
     "preferred_prefix": "biocarta.pathway",
     "uri_format": "https://cgap.nci.nih.gov/Pathways/BioCarta/$1",
     "prefix": "biocarta.pathway",
-    "all_prefixes": [
+    "synonyms": [
       "biocarta.pathway"
     ]
   },
@@ -848,7 +848,7 @@
     "preferred_prefix": "biocatalogue.service",
     "uri_format": "https://www.biocatalogue.org/services/$1",
     "prefix": "biocatalogue.service",
-    "all_prefixes": [
+    "synonyms": [
       "biocatalogue.service"
     ]
   },
@@ -859,7 +859,7 @@
     "preferred_prefix": "biocyc",
     "uri_format": "http://biocyc.org/getid?id=$1",
     "prefix": "biocyc",
-    "all_prefixes": [
+    "synonyms": [
       "biocyc"
     ]
   },
@@ -870,7 +870,7 @@
     "preferred_prefix": "biogrid",
     "uri_format": "http://thebiogrid.org/$1",
     "prefix": "biogrid",
-    "all_prefixes": [
+    "synonyms": [
       "biogrid"
     ]
   },
@@ -881,7 +881,7 @@
     "preferred_prefix": "biogrid.interaction",
     "uri_format": "https://thebiogrid.org/interaction/$1",
     "prefix": "biogrid.interaction",
-    "all_prefixes": [
+    "synonyms": [
       "biogrid.interaction"
     ]
   },
@@ -891,7 +891,7 @@
     "preferred_prefix": "biolegend",
     "uri_format": "https://www.biolegend.com/Default.aspx?ID=6664&productid=$1",
     "prefix": "biolegend",
-    "all_prefixes": [
+    "synonyms": [
       "biolegend"
     ]
   },
@@ -902,7 +902,7 @@
     "preferred_prefix": "biolink",
     "uri_format": "https://w3id.org/biolink/vocab/$1",
     "prefix": "biolink",
-    "all_prefixes": [
+    "synonyms": [
       "biolink"
     ]
   },
@@ -913,7 +913,7 @@
     "preferred_prefix": "biominder",
     "uri_format": "https://datalab.rwth-aachen.de/MINDER/resource/$1",
     "prefix": "biominder",
-    "all_prefixes": [
+    "synonyms": [
       "biominder"
     ]
   },
@@ -924,7 +924,7 @@
     "preferred_prefix": "biomodels.db",
     "uri_format": "https://www.ebi.ac.uk/biomodels/$1",
     "prefix": "biomodels.db",
-    "all_prefixes": [
+    "synonyms": [
       "biomd",
       "biomodels.db"
     ]
@@ -936,7 +936,7 @@
     "preferred_prefix": "biomodels.kisao",
     "uri_format": "http://purl.bioontology.org/ontology/KISAO/kisao:$1",
     "prefix": "biomodels.kisao",
-    "all_prefixes": [
+    "synonyms": [
       "biomodels.kisao",
       "kisao"
     ]
@@ -948,7 +948,7 @@
     "preferred_prefix": "biomodels.teddy",
     "uri_format": "http://purl.bioontology.org/ontology/TEDDY/$1",
     "prefix": "biomodels.teddy",
-    "all_prefixes": [
+    "synonyms": [
       "biomodels.teddy",
       "teddy"
     ]
@@ -960,7 +960,7 @@
     "preferred_prefix": "biomodels.vocabulary",
     "uri_format": "http://biomodels.net/rdf/vocabulary.rdf#$1",
     "prefix": "biomodels.vocabulary",
-    "all_prefixes": [
+    "synonyms": [
       "biomodels.vocabulary"
     ]
   },
@@ -971,7 +971,7 @@
     "preferred_prefix": "bionumbers",
     "uri_format": "https://bionumbers.hms.harvard.edu/bionumber.aspx?id=$1",
     "prefix": "bionumbers",
-    "all_prefixes": [
+    "synonyms": [
       "bionumbers"
     ]
   },
@@ -982,7 +982,7 @@
     "preferred_prefix": "bioportal",
     "uri_format": "http://bioportal.bioontology.org/ontologies/$1",
     "prefix": "bioportal",
-    "all_prefixes": [
+    "synonyms": [
       "bioportal"
     ]
   },
@@ -993,7 +993,7 @@
     "preferred_prefix": "bioproject",
     "uri_format": "https://www.ncbi.nlm.nih.gov/bioproject/?term=$1",
     "prefix": "bioproject",
-    "all_prefixes": [
+    "synonyms": [
       "bioproject"
     ]
   },
@@ -1003,7 +1003,7 @@
     "preferred_prefix": "bioregistry",
     "uri_format": "https://bioregistry.io/registry/$1",
     "prefix": "bioregistry",
-    "all_prefixes": [
+    "synonyms": [
       "bioregistry"
     ]
   },
@@ -1014,7 +1014,7 @@
     "preferred_prefix": "bioregistry.collection",
     "uri_format": "https://bioregistry.io/collection/$1",
     "prefix": "bioregistry.collection",
-    "all_prefixes": [
+    "synonyms": [
       "bioregistry.collection"
     ]
   },
@@ -1025,7 +1025,7 @@
     "preferred_prefix": "bioregistry.schema",
     "uri_format": "https://bioregistry.io/schema/#$1",
     "prefix": "bioregistry.schema",
-    "all_prefixes": [
+    "synonyms": [
       "bioregistry.schema"
     ]
   },
@@ -1035,7 +1035,7 @@
     "preferred_prefix": "biorxiv",
     "uri_format": "https://www.biorxiv.org/content/$1",
     "prefix": "biorxiv",
-    "all_prefixes": [
+    "synonyms": [
       "biorxiv"
     ]
   },
@@ -1046,7 +1046,7 @@
     "preferred_prefix": "biosample",
     "uri_format": "https://www.ebi.ac.uk/biosamples/sample/$1",
     "prefix": "biosample",
-    "all_prefixes": [
+    "synonyms": [
       "biosample"
     ]
   },
@@ -1057,7 +1057,7 @@
     "preferred_prefix": "biosimulations",
     "uri_format": "https://biosimulations.org/projects/$1",
     "prefix": "biosimulations",
-    "all_prefixes": [
+    "synonyms": [
       "biosimulations"
     ]
   },
@@ -1068,7 +1068,7 @@
     "preferred_prefix": "biosimulators",
     "uri_format": "https://biosimulators.org/simulators/$1",
     "prefix": "biosimulators",
-    "all_prefixes": [
+    "synonyms": [
       "biosimulators"
     ]
   },
@@ -1079,7 +1079,7 @@
     "preferred_prefix": "biostudies",
     "uri_format": "https://www.ebi.ac.uk/biostudies/studies/$1",
     "prefix": "biostudies",
-    "all_prefixes": [
+    "synonyms": [
       "biostudies"
     ]
   },
@@ -1090,7 +1090,7 @@
     "preferred_prefix": "biosystems",
     "uri_format": "https://www.ncbi.nlm.nih.gov/biosystems/$1",
     "prefix": "biosystems",
-    "all_prefixes": [
+    "synonyms": [
       "biosystems"
     ]
   },
@@ -1101,7 +1101,7 @@
     "preferred_prefix": "biotools",
     "uri_format": "https://bio.tools/$1",
     "prefix": "biotools",
-    "all_prefixes": [
+    "synonyms": [
       "biotools"
     ]
   },
@@ -1111,7 +1111,7 @@
     "preferred_prefix": "biozil",
     "uri_format": "https://www.biozol.de/en/product/$1",
     "prefix": "biozil",
-    "all_prefixes": [
+    "synonyms": [
       "biozil"
     ]
   },
@@ -1122,7 +1122,7 @@
     "preferred_prefix": "bitterdb.cpd",
     "uri_format": "http://bitterdb.agri.huji.ac.il/bitterdb/compound.php?id=$1",
     "prefix": "bitterdb.cpd",
-    "all_prefixes": [
+    "synonyms": [
       "bitterdb.cpd"
     ]
   },
@@ -1133,7 +1133,7 @@
     "preferred_prefix": "bitterdb.rec",
     "uri_format": "http://bitterdb.agri.huji.ac.il/Receptor.php?id=$1",
     "prefix": "bitterdb.rec",
-    "all_prefixes": [
+    "synonyms": [
       "bitterdb.rec"
     ]
   },
@@ -1144,7 +1144,7 @@
     "preferred_prefix": "bmrb",
     "uri_format": "http://rest.bmrb.wisc.edu/bmrb/$1/html",
     "prefix": "bmrb",
-    "all_prefixes": [
+    "synonyms": [
       "bmrb"
     ]
   },
@@ -1154,7 +1154,7 @@
     "preferred_prefix": "bmrb.restraint",
     "uri_format": "https://restraintsgrid.bmrb.io/NRG/MRGridServlet?block_text_type=2-parsed&db_username=wattos1&file_detail=2-parsed&format=n%2Fa&program=STAR&request_type=block&subtype=full&type=entry&mrblock_id=$1",
     "prefix": "bmrb.restraint",
-    "all_prefixes": [
+    "synonyms": [
       "bmrb.restraint"
     ]
   },
@@ -1165,7 +1165,7 @@
     "preferred_prefix": "bold.taxonomy",
     "uri_format": "http://www.boldsystems.org/index.php/Taxbrowser_Taxonpage?taxid=$1",
     "prefix": "bold.taxonomy",
-    "all_prefixes": [
+    "synonyms": [
       "bold.taxonomy"
     ]
   },
@@ -1175,7 +1175,7 @@
     "preferred_prefix": "BOOTSTREP",
     "uri_format": "http://purl.obolibrary.org/obo/BOOTSTREP_$1",
     "prefix": "bootstrep",
-    "all_prefixes": [
+    "synonyms": [
       "bootstrep"
     ]
   },
@@ -1185,7 +1185,7 @@
     "preferred_prefix": "bpdb",
     "uri_format": "https://sitem.herts.ac.uk/aeru/bpdb/Reports/$1.htm",
     "prefix": "bpdb",
-    "all_prefixes": [
+    "synonyms": [
       "bpdb"
     ]
   },
@@ -1196,7 +1196,7 @@
     "preferred_prefix": "brenda",
     "uri_format": "https://www.brenda-enzymes.org/php/result_flat.php4?ecno=$1",
     "prefix": "brenda",
-    "all_prefixes": [
+    "synonyms": [
       "brenda"
     ]
   },
@@ -1207,7 +1207,7 @@
     "preferred_prefix": "broad",
     "uri_format": "https://www.broadinstitute.org/annotation/genome/magnaporthe_grisea/GeneDetails.html?sp=$1",
     "prefix": "broad",
-    "all_prefixes": [
+    "synonyms": [
       "broad"
     ]
   },
@@ -1218,7 +1218,7 @@
     "preferred_prefix": "BSPO",
     "uri_format": "http://purl.obolibrary.org/obo/BSPO_$1",
     "prefix": "bspo",
-    "all_prefixes": [
+    "synonyms": [
       "bspo"
     ]
   },
@@ -1229,7 +1229,7 @@
     "preferred_prefix": "BTO",
     "uri_format": "https://www.ebi.ac.uk/ols/ontologies/bto/terms?obo_id=BTO:$1",
     "prefix": "bto",
-    "all_prefixes": [
+    "synonyms": [
       "bto"
     ]
   },
@@ -1240,7 +1240,7 @@
     "preferred_prefix": "bugbase.expt",
     "uri_format": "http://bugs.sgul.ac.uk/bugsbase/tabs/experiment.php?expt_id=$1&action=view",
     "prefix": "bugbase.expt",
-    "all_prefixes": [
+    "synonyms": [
       "bugbase.expt"
     ]
   },
@@ -1251,7 +1251,7 @@
     "preferred_prefix": "bugbase.protocol",
     "uri_format": "http://bugs.sgul.ac.uk/bugsbase/tabs/protocol.php?protocol_id=$1&amp;action=view",
     "prefix": "bugbase.protocol",
-    "all_prefixes": [
+    "synonyms": [
       "bugbase.protocol"
     ]
   },
@@ -1262,7 +1262,7 @@
     "preferred_prefix": "bykdb",
     "uri_format": "https://bykdb.ibcp.fr/data/html/annotated/$1.html",
     "prefix": "bykdb",
-    "all_prefixes": [
+    "synonyms": [
       "bykdb"
     ]
   },
@@ -1273,7 +1273,7 @@
     "preferred_prefix": "cabri",
     "uri_format": "http://www.cabri.org/CABRI/srs-bin/wgetz?-e+-page+EntryPage+[$1]",
     "prefix": "cabri",
-    "all_prefixes": [
+    "synonyms": [
       "cabri"
     ]
   },
@@ -1284,7 +1284,7 @@
     "preferred_prefix": "cadsr",
     "uri_format": "https://cadsrapi.nci.nih.gov/cadsrapi4/GetXML?query=DataElement[@publicId=$1]",
     "prefix": "cadsr",
-    "all_prefixes": [
+    "synonyms": [
       "cadsr"
     ]
   },
@@ -1295,7 +1295,7 @@
     "preferred_prefix": "cameo",
     "uri_format": "https://www.cameo3d.org/sp/targets/target/$1",
     "prefix": "cameo",
-    "all_prefixes": [
+    "synonyms": [
       "cameo"
     ]
   },
@@ -1306,7 +1306,7 @@
     "preferred_prefix": "caps",
     "uri_format": "http://www.bioinsilico.org/cgi-bin/CAPSDB/getCAPScluster?nidcl=$1",
     "prefix": "caps",
-    "all_prefixes": [
+    "synonyms": [
       "caps"
     ]
   },
@@ -1316,7 +1316,7 @@
     "preferred_prefix": "CARO",
     "uri_format": "http://purl.obolibrary.org/obo/CARO_$1",
     "prefix": "caro",
-    "all_prefixes": [
+    "synonyms": [
       "caro"
     ]
   },
@@ -1327,7 +1327,7 @@
     "preferred_prefix": "cas",
     "uri_format": "https://commonchemistry.cas.org/detail?ref=$1",
     "prefix": "cas",
-    "all_prefixes": [
+    "synonyms": [
       "cas",
       "cas_id",
       "cas_rn",
@@ -1342,7 +1342,7 @@
     "preferred_prefix": "cath",
     "uri_format": "http://www.cathdb.info/cathnode/$1",
     "prefix": "cath",
-    "all_prefixes": [
+    "synonyms": [
       "cath"
     ]
   },
@@ -1353,7 +1353,7 @@
     "preferred_prefix": "cath.domain",
     "uri_format": "http://www.cathdb.info/domain/$1",
     "prefix": "cath.domain",
-    "all_prefixes": [
+    "synonyms": [
       "cath.domain"
     ]
   },
@@ -1364,7 +1364,7 @@
     "preferred_prefix": "cath.superfamily",
     "uri_format": "http://www.cathdb.info/cathnode/$1",
     "prefix": "cath.superfamily",
-    "all_prefixes": [
+    "synonyms": [
       "cath.superfamily"
     ]
   },
@@ -1375,7 +1375,7 @@
     "preferred_prefix": "cattleqtldb",
     "uri_format": "https://www.animalgenome.org/QTLdb/q?id=QTL_ID:$1",
     "prefix": "cattleqtldb",
-    "all_prefixes": [
+    "synonyms": [
       "cattleqtldb"
     ]
   },
@@ -1386,7 +1386,7 @@
     "preferred_prefix": "cazy",
     "uri_format": "http://www.cazy.org/$1.html",
     "prefix": "cazy",
-    "all_prefixes": [
+    "synonyms": [
       "cazy"
     ]
   },
@@ -1396,7 +1396,7 @@
     "preferred_prefix": "cba",
     "uri_format": "https://europepmc.org/article/CBA/$1",
     "prefix": "cba",
-    "all_prefixes": [
+    "synonyms": [
       "cba"
     ]
   },
@@ -1407,7 +1407,7 @@
     "preferred_prefix": "cbioportal",
     "uri_format": "https://www.cbioportal.org/study/summary?id=$1",
     "prefix": "cbioportal",
-    "all_prefixes": [
+    "synonyms": [
       "cbioportal"
     ]
   },
@@ -1418,7 +1418,7 @@
     "preferred_prefix": "ccdc",
     "uri_format": "https://www.ccdc.cam.ac.uk/services/structures?pid=ccdc:$1&sid=IDORG",
     "prefix": "ccdc",
-    "all_prefixes": [
+    "synonyms": [
       "ccdc"
     ]
   },
@@ -1429,7 +1429,7 @@
     "preferred_prefix": "ccds",
     "uri_format": "http://www.ncbi.nlm.nih.gov/CCDS/CcdsBrowse.cgi?REQUEST=CCDS&DATA=$1",
     "prefix": "ccds",
-    "all_prefixes": [
+    "synonyms": [
       "ccds"
     ]
   },
@@ -1439,7 +1439,7 @@
     "preferred_prefix": "ccle",
     "uri_format": "https://www.cbioportal.org/patient?studyId=ccle_broad_2019&caseId=$1",
     "prefix": "ccle",
-    "all_prefixes": [
+    "synonyms": [
       "ccle",
       "ccle.cell"
     ]
@@ -1451,7 +1451,7 @@
     "preferred_prefix": "cco",
     "uri_format": "https://www.ebi.ac.uk/ols/ontologies/cco/terms?obo_id=CCO:$1",
     "prefix": "cco",
-    "all_prefixes": [
+    "synonyms": [
       "cco"
     ]
   },
@@ -1461,7 +1461,7 @@
     "preferred_prefix": "CDAO",
     "uri_format": "http://purl.obolibrary.org/obo/CDAO_$1",
     "prefix": "cdao",
-    "all_prefixes": [
+    "synonyms": [
       "cdao"
     ]
   },
@@ -1472,7 +1472,7 @@
     "preferred_prefix": "cdd",
     "uri_format": "https://www.ncbi.nlm.nih.gov/Structure/cdd/cddsrv.cgi?uid=$1",
     "prefix": "cdd",
-    "all_prefixes": [
+    "synonyms": [
       "cdd"
     ]
   },
@@ -1482,7 +1482,7 @@
     "preferred_prefix": "CDNO",
     "uri_format": "http://purl.obolibrary.org/obo/CDNO_$1",
     "prefix": "cdno",
-    "all_prefixes": [
+    "synonyms": [
       "cdno"
     ]
   },
@@ -1493,7 +1493,7 @@
     "preferred_prefix": "cdpd",
     "uri_format": "http://webprod3.hc-sc.gc.ca/dpd-bdpp/info.do?lang=eng&code=$1",
     "prefix": "cdpd",
-    "all_prefixes": [
+    "synonyms": [
       "cdpd"
     ]
   },
@@ -1503,7 +1503,7 @@
     "preferred_prefix": "cellbank.australia",
     "uri_format": "https://www.cellbankaustralia.com/$1.html",
     "prefix": "cellbank.australia",
-    "all_prefixes": [
+    "synonyms": [
       "cellbank.australia"
     ]
   },
@@ -1514,7 +1514,7 @@
     "preferred_prefix": "cellimage",
     "uri_format": "http://cellimagelibrary.org/images/$1",
     "prefix": "cellimage",
-    "all_prefixes": [
+    "synonyms": [
       "cellimage"
     ]
   },
@@ -1525,7 +1525,7 @@
     "preferred_prefix": "cellosaurus",
     "uri_format": "https://web.expasy.org/cellosaurus/$1",
     "prefix": "cellosaurus",
-    "all_prefixes": [
+    "synonyms": [
       "cellosaurus",
       "cvcl"
     ]
@@ -1537,7 +1537,7 @@
     "preferred_prefix": "cellrepo",
     "uri_format": "https://cellrepo.ico2s.org/repositories/$1",
     "prefix": "cellrepo",
-    "all_prefixes": [
+    "synonyms": [
       "cellrepo"
     ]
   },
@@ -1548,7 +1548,7 @@
     "preferred_prefix": "CEPH",
     "uri_format": "http://purl.obolibrary.org/obo/CEPH_$1",
     "prefix": "ceph",
-    "all_prefixes": [
+    "synonyms": [
       "ceph"
     ]
   },
@@ -1559,7 +1559,7 @@
     "preferred_prefix": "cgd",
     "uri_format": "http://www.candidagenome.org/cgi-bin/locus.pl?dbid=$1",
     "prefix": "cgd",
-    "all_prefixes": [
+    "synonyms": [
       "cgd"
     ]
   },
@@ -1569,7 +1569,7 @@
     "preferred_prefix": "cgnc",
     "uri_format": "http://birdgenenames.org/cgnc/GeneReport?id=$1",
     "prefix": "cgnc",
-    "all_prefixes": [
+    "synonyms": [
       "birdbase",
       "cgnc"
     ]
@@ -1581,7 +1581,7 @@
     "preferred_prefix": "cgsc",
     "uri_format": "http://cgsc.biology.yale.edu/Site.php?ID=$1",
     "prefix": "cgsc",
-    "all_prefixes": [
+    "synonyms": [
       "cgsc"
     ]
   },
@@ -1592,7 +1592,7 @@
     "preferred_prefix": "charprot",
     "uri_format": "http://www.jcvi.org/charprotdb/index.cgi/view/$1",
     "prefix": "charprot",
-    "all_prefixes": [
+    "synonyms": [
       "charprot"
     ]
   },
@@ -1603,7 +1603,7 @@
     "preferred_prefix": "CHEBI",
     "uri_format": "https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:$1",
     "prefix": "chebi",
-    "all_prefixes": [
+    "synonyms": [
       "chebi",
       "chebiid"
     ]
@@ -1615,7 +1615,7 @@
     "preferred_prefix": "chembl",
     "uri_format": "https://www.ebi.ac.uk/chembl/entity/$1",
     "prefix": "chembl",
-    "all_prefixes": [
+    "synonyms": [
       "chembl",
       "chembl_id"
     ]
@@ -1627,7 +1627,7 @@
     "preferred_prefix": "chembl.compound",
     "uri_format": "https://www.ebi.ac.uk/chembl/compound/inspect/$1",
     "prefix": "chembl.compound",
-    "all_prefixes": [
+    "synonyms": [
       "chembl.compound"
     ]
   },
@@ -1638,7 +1638,7 @@
     "preferred_prefix": "chembl.target",
     "uri_format": "https://www.ebi.ac.uk/chembl/target/inspect/$1",
     "prefix": "chembl.target",
-    "all_prefixes": [
+    "synonyms": [
       "chembl.target"
     ]
   },
@@ -1649,7 +1649,7 @@
     "preferred_prefix": "chemdb",
     "uri_format": "http://cdb.ics.uci.edu/cgibin/ChemicalDetailWeb.py?chemical_id=$1",
     "prefix": "chemdb",
-    "all_prefixes": [
+    "synonyms": [
       "chemdb"
     ]
   },
@@ -1660,7 +1660,7 @@
     "preferred_prefix": "chemidplus",
     "uri_format": "https://chem.nlm.nih.gov/chemidplus/rn/$1",
     "prefix": "chemidplus",
-    "all_prefixes": [
+    "synonyms": [
       "chemidplus"
     ]
   },
@@ -1670,7 +1670,7 @@
     "preferred_prefix": "CHEMINF",
     "uri_format": "http://purl.obolibrary.org/obo/CHEMINF_$1",
     "prefix": "cheminf",
-    "all_prefixes": [
+    "synonyms": [
       "cheminf"
     ]
   },
@@ -1681,7 +1681,7 @@
     "preferred_prefix": "chemspider",
     "uri_format": "http://www.chemspider.com/Chemical-Structure.$1.html",
     "prefix": "chemspider",
-    "all_prefixes": [
+    "synonyms": [
       "chemspider"
     ]
   },
@@ -1692,7 +1692,7 @@
     "preferred_prefix": "chickenqtldb",
     "uri_format": "https://www.animalgenome.org/QTLdb/q?id=QTL_ID:$1",
     "prefix": "chickenqtldb",
-    "all_prefixes": [
+    "synonyms": [
       "chickenqtldb"
     ]
   },
@@ -1701,7 +1701,7 @@
     "preferred_prefix": "CHIRO",
     "uri_format": "http://purl.obolibrary.org/obo/CHIRO_$1",
     "prefix": "chiro",
-    "all_prefixes": [
+    "synonyms": [
       "chiro"
     ]
   },
@@ -1712,7 +1712,7 @@
     "preferred_prefix": "CHMO",
     "uri_format": "http://purl.obolibrary.org/obo/CHMO_$1",
     "prefix": "chmo",
-    "all_prefixes": [
+    "synonyms": [
       "chmo"
     ]
   },
@@ -1722,7 +1722,7 @@
     "preferred_prefix": "CIDO",
     "uri_format": "http://purl.obolibrary.org/obo/CIDO_$1",
     "prefix": "cido",
-    "all_prefixes": [
+    "synonyms": [
       "cido"
     ]
   },
@@ -1733,7 +1733,7 @@
     "preferred_prefix": "CIO",
     "uri_format": "http://purl.obolibrary.org/obo/CIO_$1",
     "prefix": "cio",
-    "all_prefixes": [
+    "synonyms": [
       "cio"
     ]
   },
@@ -1743,7 +1743,7 @@
     "preferred_prefix": "citexplore",
     "uri_format": "https://europepmc.org/article/CTX/$1",
     "prefix": "citexplore",
-    "all_prefixes": [
+    "synonyms": [
       "citexplore",
       "ctx"
     ]
@@ -1755,7 +1755,7 @@
     "preferred_prefix": "civic.aid",
     "uri_format": "https://civicdb.org/links/assertions/$1",
     "prefix": "civic.aid",
-    "all_prefixes": [
+    "synonyms": [
       "civic.aid"
     ]
   },
@@ -1766,7 +1766,7 @@
     "preferred_prefix": "civic.eid",
     "uri_format": "https://civicdb.org/links/evidence/$1",
     "prefix": "civic.eid",
-    "all_prefixes": [
+    "synonyms": [
       "civic.eid"
     ]
   },
@@ -1777,7 +1777,7 @@
     "preferred_prefix": "CL",
     "uri_format": "https://www.ebi.ac.uk/ols/ontologies/cl/terms?obo_id=CL:$1",
     "prefix": "cl",
-    "all_prefixes": [
+    "synonyms": [
       "cl"
     ]
   },
@@ -1787,7 +1787,7 @@
     "preferred_prefix": "CLAO",
     "uri_format": "http://purl.obolibrary.org/obo/CLAO_$1",
     "prefix": "clao",
-    "all_prefixes": [
+    "synonyms": [
       "clao"
     ]
   },
@@ -1798,7 +1798,7 @@
     "preferred_prefix": "classyfire",
     "uri_format": "http://classyfire.wishartlab.com/tax_nodes/$1",
     "prefix": "classyfire",
-    "all_prefixes": [
+    "synonyms": [
       "classyfire"
     ]
   },
@@ -1809,7 +1809,7 @@
     "preferred_prefix": "cldb",
     "uri_format": "http://bioinformatics.hsanmartino.it/hypercldb/$1.html",
     "prefix": "cldb",
-    "all_prefixes": [
+    "synonyms": [
       "cldb"
     ]
   },
@@ -1819,7 +1819,7 @@
     "preferred_prefix": "clingene",
     "uri_format": "https://reg.clinicalgenome.org/redmine/projects/registry/genboree_registry/by_caid?caid=$1",
     "prefix": "clingene",
-    "all_prefixes": [
+    "synonyms": [
       "clingene"
     ]
   },
@@ -1830,7 +1830,7 @@
     "preferred_prefix": "clinicaltrials",
     "uri_format": "https://clinicaltrials.gov/ct2/show/$1",
     "prefix": "clinicaltrials",
-    "all_prefixes": [
+    "synonyms": [
       "clinicaltrials"
     ]
   },
@@ -1841,7 +1841,7 @@
     "preferred_prefix": "clinvar",
     "uri_format": "https://www.ncbi.nlm.nih.gov/clinvar/variation/$1",
     "prefix": "clinvar",
-    "all_prefixes": [
+    "synonyms": [
       "clinvar"
     ]
   },
@@ -1852,7 +1852,7 @@
     "preferred_prefix": "clinvar.record",
     "uri_format": "http://www.ncbi.nlm.nih.gov/clinvar/$1",
     "prefix": "clinvar.record",
-    "all_prefixes": [
+    "synonyms": [
       "clinvar.record"
     ]
   },
@@ -1863,7 +1863,7 @@
     "preferred_prefix": "clinvar.submission",
     "uri_format": "http://www.ncbi.nlm.nih.gov/clinvar?term=$1",
     "prefix": "clinvar.submission",
-    "all_prefixes": [
+    "synonyms": [
       "clinvar.submission"
     ]
   },
@@ -1874,7 +1874,7 @@
     "preferred_prefix": "clinvar.submitter",
     "uri_format": "https://www.ncbi.nlm.nih.gov/clinvar/submitters/$1",
     "prefix": "clinvar.submitter",
-    "all_prefixes": [
+    "synonyms": [
       "clinvar.submitter"
     ]
   },
@@ -1884,7 +1884,7 @@
     "preferred_prefix": "CLO",
     "uri_format": "http://purl.obolibrary.org/obo/CLO_$1",
     "prefix": "clo",
-    "all_prefixes": [
+    "synonyms": [
       "clo"
     ]
   },
@@ -1894,7 +1894,7 @@
     "preferred_prefix": "CLYH",
     "uri_format": "http://purl.obolibrary.org/obo/CLYH_$1",
     "prefix": "clyh",
-    "all_prefixes": [
+    "synonyms": [
       "clyh"
     ]
   },
@@ -1904,7 +1904,7 @@
     "preferred_prefix": "CMF",
     "uri_format": "http://purl.obolibrary.org/obo/CMF_$1",
     "prefix": "cmf",
-    "all_prefixes": [
+    "synonyms": [
       "cmf"
     ]
   },
@@ -1915,7 +1915,7 @@
     "preferred_prefix": "CMO",
     "uri_format": "http://purl.obolibrary.org/obo/CMO_$1",
     "prefix": "cmo",
-    "all_prefixes": [
+    "synonyms": [
       "cmo"
     ]
   },
@@ -1925,7 +1925,7 @@
     "preferred_prefix": "co_320",
     "uri_format": "https://www.cropontology.org/rdf/CO_320:$1",
     "prefix": "co_320",
-    "all_prefixes": [
+    "synonyms": [
       "co_320"
     ]
   },
@@ -1935,7 +1935,7 @@
     "preferred_prefix": "co_321",
     "uri_format": "https://www.cropontology.org/rdf/CO_321:$1",
     "prefix": "co_321",
-    "all_prefixes": [
+    "synonyms": [
       "co_321"
     ]
   },
@@ -1945,7 +1945,7 @@
     "preferred_prefix": "co_322",
     "uri_format": "https://www.cropontology.org/rdf/CO_322:$1",
     "prefix": "co_322",
-    "all_prefixes": [
+    "synonyms": [
       "co_322"
     ]
   },
@@ -1955,7 +1955,7 @@
     "preferred_prefix": "co_323",
     "uri_format": "https://www.cropontology.org/rdf/CO_323:$1",
     "prefix": "co_323",
-    "all_prefixes": [
+    "synonyms": [
       "co_323"
     ]
   },
@@ -1965,7 +1965,7 @@
     "preferred_prefix": "co_324",
     "uri_format": "https://www.cropontology.org/rdf/CO_324:$1",
     "prefix": "co_324",
-    "all_prefixes": [
+    "synonyms": [
       "co_324"
     ]
   },
@@ -1975,7 +1975,7 @@
     "preferred_prefix": "co_325",
     "uri_format": "https://www.cropontology.org/rdf/CO_325:$1",
     "prefix": "co_325",
-    "all_prefixes": [
+    "synonyms": [
       "co_325"
     ]
   },
@@ -1985,7 +1985,7 @@
     "preferred_prefix": "co_327",
     "uri_format": "https://www.cropontology.org/rdf/CO_327:$1",
     "prefix": "co_327",
-    "all_prefixes": [
+    "synonyms": [
       "co_327"
     ]
   },
@@ -1995,7 +1995,7 @@
     "preferred_prefix": "co_330",
     "uri_format": "https://www.cropontology.org/rdf/CO_330:$1",
     "prefix": "co_330",
-    "all_prefixes": [
+    "synonyms": [
       "co_330"
     ]
   },
@@ -2005,7 +2005,7 @@
     "preferred_prefix": "co_331",
     "uri_format": "https://www.cropontology.org/rdf/CO_331:$1",
     "prefix": "co_331",
-    "all_prefixes": [
+    "synonyms": [
       "co_331"
     ]
   },
@@ -2015,7 +2015,7 @@
     "preferred_prefix": "co_333",
     "uri_format": "https://www.cropontology.org/rdf/CO_333:$1",
     "prefix": "co_333",
-    "all_prefixes": [
+    "synonyms": [
       "co_333"
     ]
   },
@@ -2025,7 +2025,7 @@
     "preferred_prefix": "co_334",
     "uri_format": "https://www.cropontology.org/rdf/CO_334:$1",
     "prefix": "co_334",
-    "all_prefixes": [
+    "synonyms": [
       "co_334"
     ]
   },
@@ -2035,7 +2035,7 @@
     "preferred_prefix": "co_335",
     "uri_format": "https://www.cropontology.org/rdf/CO_335:$1",
     "prefix": "co_335",
-    "all_prefixes": [
+    "synonyms": [
       "co_335"
     ]
   },
@@ -2045,7 +2045,7 @@
     "preferred_prefix": "co_336",
     "uri_format": "https://www.cropontology.org/rdf/CO_336:$1",
     "prefix": "co_336",
-    "all_prefixes": [
+    "synonyms": [
       "co_336"
     ]
   },
@@ -2055,7 +2055,7 @@
     "preferred_prefix": "co_337",
     "uri_format": "https://www.cropontology.org/rdf/CO_337:$1",
     "prefix": "co_337",
-    "all_prefixes": [
+    "synonyms": [
       "co_337"
     ]
   },
@@ -2065,7 +2065,7 @@
     "preferred_prefix": "co_338",
     "uri_format": "https://www.cropontology.org/rdf/CO_338:$1",
     "prefix": "co_338",
-    "all_prefixes": [
+    "synonyms": [
       "co_338"
     ]
   },
@@ -2075,7 +2075,7 @@
     "preferred_prefix": "co_339",
     "uri_format": "https://www.cropontology.org/rdf/CO_339:$1",
     "prefix": "co_339",
-    "all_prefixes": [
+    "synonyms": [
       "co_339"
     ]
   },
@@ -2085,7 +2085,7 @@
     "preferred_prefix": "co_340",
     "uri_format": "https://www.cropontology.org/rdf/CO_340:$1",
     "prefix": "co_340",
-    "all_prefixes": [
+    "synonyms": [
       "co_340"
     ]
   },
@@ -2095,7 +2095,7 @@
     "preferred_prefix": "co_341",
     "uri_format": "https://www.cropontology.org/rdf/CO_341:$1",
     "prefix": "co_341",
-    "all_prefixes": [
+    "synonyms": [
       "co_341"
     ]
   },
@@ -2105,7 +2105,7 @@
     "preferred_prefix": "co_343",
     "uri_format": "https://www.cropontology.org/rdf/CO_343:$1",
     "prefix": "co_343",
-    "all_prefixes": [
+    "synonyms": [
       "co_343"
     ]
   },
@@ -2115,7 +2115,7 @@
     "preferred_prefix": "co_345",
     "uri_format": "https://www.cropontology.org/rdf/CO_345:$1",
     "prefix": "co_345",
-    "all_prefixes": [
+    "synonyms": [
       "co_345"
     ]
   },
@@ -2125,7 +2125,7 @@
     "preferred_prefix": "co_346",
     "uri_format": "https://www.cropontology.org/rdf/CO_346:$1",
     "prefix": "co_346",
-    "all_prefixes": [
+    "synonyms": [
       "co_346"
     ]
   },
@@ -2135,7 +2135,7 @@
     "preferred_prefix": "co_347",
     "uri_format": "https://www.cropontology.org/rdf/CO_347:$1",
     "prefix": "co_347",
-    "all_prefixes": [
+    "synonyms": [
       "co_347"
     ]
   },
@@ -2145,7 +2145,7 @@
     "preferred_prefix": "co_348",
     "uri_format": "https://www.cropontology.org/rdf/CO_348:$1",
     "prefix": "co_348",
-    "all_prefixes": [
+    "synonyms": [
       "co_348"
     ]
   },
@@ -2155,7 +2155,7 @@
     "preferred_prefix": "co_350",
     "uri_format": "https://www.cropontology.org/rdf/CO_350:$1",
     "prefix": "co_350",
-    "all_prefixes": [
+    "synonyms": [
       "co_350"
     ]
   },
@@ -2165,7 +2165,7 @@
     "preferred_prefix": "co_356",
     "uri_format": "https://www.cropontology.org/rdf/CO_356:$1",
     "prefix": "co_356",
-    "all_prefixes": [
+    "synonyms": [
       "co_356"
     ]
   },
@@ -2175,7 +2175,7 @@
     "preferred_prefix": "co_357",
     "uri_format": "https://www.cropontology.org/rdf/CO_357:$1",
     "prefix": "co_357",
-    "all_prefixes": [
+    "synonyms": [
       "co_357"
     ]
   },
@@ -2185,7 +2185,7 @@
     "preferred_prefix": "co_358",
     "uri_format": "https://www.cropontology.org/rdf/CO_358:$1",
     "prefix": "co_358",
-    "all_prefixes": [
+    "synonyms": [
       "co_358"
     ]
   },
@@ -2195,7 +2195,7 @@
     "preferred_prefix": "co_359",
     "uri_format": "https://www.cropontology.org/rdf/CO_359:$1",
     "prefix": "co_359",
-    "all_prefixes": [
+    "synonyms": [
       "co_359"
     ]
   },
@@ -2205,7 +2205,7 @@
     "preferred_prefix": "co_360",
     "uri_format": "https://www.cropontology.org/rdf/CO_360:$1",
     "prefix": "co_360",
-    "all_prefixes": [
+    "synonyms": [
       "co_360"
     ]
   },
@@ -2215,7 +2215,7 @@
     "preferred_prefix": "co_365",
     "uri_format": "https://www.cropontology.org/rdf/CO_365:$1",
     "prefix": "co_365",
-    "all_prefixes": [
+    "synonyms": [
       "co_365"
     ]
   },
@@ -2225,7 +2225,7 @@
     "preferred_prefix": "co_366",
     "uri_format": "https://www.cropontology.org/rdf/CO_366:$1",
     "prefix": "co_366",
-    "all_prefixes": [
+    "synonyms": [
       "co_366"
     ]
   },
@@ -2235,7 +2235,7 @@
     "preferred_prefix": "COB",
     "uri_format": "http://purl.obolibrary.org/obo/COB_$1",
     "prefix": "cob",
-    "all_prefixes": [
+    "synonyms": [
       "cob"
     ]
   },
@@ -2246,7 +2246,7 @@
     "preferred_prefix": "coconut",
     "uri_format": "https://coconut.naturalproducts.net/compound/coconut_id/$1",
     "prefix": "coconut",
-    "all_prefixes": [
+    "synonyms": [
       "coconut"
     ]
   },
@@ -2257,7 +2257,7 @@
     "preferred_prefix": "cog",
     "uri_format": "https://www.ncbi.nlm.nih.gov/research/cog/cog/$1",
     "prefix": "cog",
-    "all_prefixes": [
+    "synonyms": [
       "cog",
       "cog_cluster"
     ]
@@ -2268,7 +2268,7 @@
     "preferred_prefix": "cog.category",
     "uri_format": "https://www.ncbi.nlm.nih.gov/research/cog/cogcategory/$1",
     "prefix": "cog.category",
-    "all_prefixes": [
+    "synonyms": [
       "cog.category"
     ]
   },
@@ -2278,7 +2278,7 @@
     "preferred_prefix": "cog.pathway",
     "uri_format": "https://www.ncbi.nlm.nih.gov/research/cog/pathway/$1",
     "prefix": "cog.pathway",
-    "all_prefixes": [
+    "synonyms": [
       "cog.pathway"
     ]
   },
@@ -2289,7 +2289,7 @@
     "preferred_prefix": "combine.specifications",
     "uri_format": "https://co.mbine.org/specifications/$1",
     "prefix": "combine.specifications",
-    "all_prefixes": [
+    "synonyms": [
       "combine.specifications"
     ]
   },
@@ -2299,7 +2299,7 @@
     "preferred_prefix": "come",
     "uri_format": "https://www.flymine.org/come/entry?gn=$1",
     "prefix": "come",
-    "all_prefixes": [
+    "synonyms": [
       "come"
     ]
   },
@@ -2310,7 +2310,7 @@
     "preferred_prefix": "complexportal",
     "uri_format": "https://www.ebi.ac.uk/complexportal/complex/$1",
     "prefix": "complexportal",
-    "all_prefixes": [
+    "synonyms": [
       "complexportal"
     ]
   },
@@ -2321,7 +2321,7 @@
     "preferred_prefix": "comptox",
     "uri_format": "https://comptox.epa.gov/dashboard/$1",
     "prefix": "comptox",
-    "all_prefixes": [
+    "synonyms": [
       "comptox"
     ]
   },
@@ -2332,7 +2332,7 @@
     "preferred_prefix": "compulyeast",
     "uri_format": "http://compluyeast2dpage.dacya.ucm.es/cgi-bin/2d/2d.cgi?ac=$1",
     "prefix": "compulyeast",
-    "all_prefixes": [
+    "synonyms": [
       "compulyeast"
     ]
   },
@@ -2343,7 +2343,7 @@
     "preferred_prefix": "conoserver",
     "uri_format": "http://www.conoserver.org/?page=card&table=protein&id=$1",
     "prefix": "conoserver",
-    "all_prefixes": [
+    "synonyms": [
       "conoserver"
     ]
   },
@@ -2354,7 +2354,7 @@
     "preferred_prefix": "conso",
     "uri_format": "https://pharmacome.github.io/conso/$1",
     "prefix": "conso",
-    "all_prefixes": [
+    "synonyms": [
       "conso"
     ]
   },
@@ -2365,7 +2365,7 @@
     "preferred_prefix": "coriell",
     "uri_format": "http://ccr.coriell.org/Sections/Search/Sample_Detail.aspx?Ref=$1",
     "prefix": "coriell",
-    "all_prefixes": [
+    "synonyms": [
       "coriell"
     ]
   },
@@ -2376,7 +2376,7 @@
     "preferred_prefix": "corrdb",
     "uri_format": "https://www.animalgenome.org/CorrDB/q/?id=CorrID:$1",
     "prefix": "corrdb",
-    "all_prefixes": [
+    "synonyms": [
       "corrdb"
     ]
   },
@@ -2387,7 +2387,7 @@
     "preferred_prefix": "corum",
     "uri_format": "https://mips.helmholtz-muenchen.de/corum/?id=$1",
     "prefix": "corum",
-    "all_prefixes": [
+    "synonyms": [
       "corum"
     ]
   },
@@ -2398,7 +2398,7 @@
     "preferred_prefix": "cosmic",
     "uri_format": "http://cancer.sanger.ac.uk/cosmic/gene/overview?ln=$1",
     "prefix": "cosmic",
-    "all_prefixes": [
+    "synonyms": [
       "cosmic"
     ]
   },
@@ -2408,7 +2408,7 @@
     "preferred_prefix": "cosmic.cell",
     "uri_format": "https://cancer.sanger.ac.uk/cell_lines/sample/overview?id=$1",
     "prefix": "cosmic.cell",
-    "all_prefixes": [
+    "synonyms": [
       "cosmic.cell"
     ]
   },
@@ -2419,7 +2419,7 @@
     "preferred_prefix": "covid19",
     "uri_format": "https://covid19.sfb.uit.no/api/records/$1",
     "prefix": "covid19",
-    "all_prefixes": [
+    "synonyms": [
       "covid19"
     ]
   },
@@ -2430,7 +2430,7 @@
     "preferred_prefix": "cpc",
     "uri_format": "https://worldwide.espacenet.com/classification?locale=en_EP#!/CPC=$1",
     "prefix": "cpc",
-    "all_prefixes": [
+    "synonyms": [
       "cpc"
     ]
   },
@@ -2440,7 +2440,7 @@
     "preferred_prefix": "GRO",
     "uri_format": "http://purl.obolibrary.org/obo/GRO_$1",
     "prefix": "cpga",
-    "all_prefixes": [
+    "synonyms": [
       "cpga"
     ]
   },
@@ -2451,7 +2451,7 @@
     "preferred_prefix": "crisprdb",
     "uri_format": "http://crispr.i2bc.paris-saclay.fr/cgi-bin/crispr/SpecieProperties_db.cgi?Taxon_id[]=$1",
     "prefix": "crisprdb",
-    "all_prefixes": [
+    "synonyms": [
       "crisprdb"
     ]
   },
@@ -2462,7 +2462,7 @@
     "preferred_prefix": "CRO",
     "uri_format": "http://purl.obolibrary.org/obo/CRO_$1",
     "prefix": "cro",
-    "all_prefixes": [
+    "synonyms": [
       "cro"
     ]
   },
@@ -2473,7 +2473,7 @@
     "preferred_prefix": "cryptodb",
     "uri_format": "https://cryptodb.org/cryptodb/app/record/gene/$1",
     "prefix": "cryptodb",
-    "all_prefixes": [
+    "synonyms": [
       "cryptodb"
     ]
   },
@@ -2484,7 +2484,7 @@
     "preferred_prefix": "csa",
     "uri_format": "https://www.ebi.ac.uk/thornton-srv/databases/CSA/SearchResults.php?PDBID=$1",
     "prefix": "csa",
-    "all_prefixes": [
+    "synonyms": [
       "csa"
     ]
   },
@@ -2495,7 +2495,7 @@
     "preferred_prefix": "csd",
     "uri_format": "https://www.ccdc.cam.ac.uk/services/structures?pid=csd:$1&sid=IDORG",
     "prefix": "csd",
-    "all_prefixes": [
+    "synonyms": [
       "csd"
     ]
   },
@@ -2506,7 +2506,7 @@
     "preferred_prefix": "cst",
     "uri_format": "http://www.cellsignal.com/reference/pathway/$1.html",
     "prefix": "cst",
-    "all_prefixes": [
+    "synonyms": [
       "cst"
     ]
   },
@@ -2517,7 +2517,7 @@
     "preferred_prefix": "cst.ab",
     "uri_format": "http://www.cellsignal.com/products/$1.html",
     "prefix": "cst.ab",
-    "all_prefixes": [
+    "synonyms": [
       "cst.ab"
     ]
   },
@@ -2528,7 +2528,7 @@
     "preferred_prefix": "ctd.chemical",
     "uri_format": "http://ctdbase.org/detail.go?type=chem&acc=$1",
     "prefix": "ctd.chemical",
-    "all_prefixes": [
+    "synonyms": [
       "ctd.chemical"
     ]
   },
@@ -2539,7 +2539,7 @@
     "preferred_prefix": "ctd.disease",
     "uri_format": "http://ctdbase.org/detail.go?type=disease&db=MESH&acc=$1",
     "prefix": "ctd.disease",
-    "all_prefixes": [
+    "synonyms": [
       "ctd.disease"
     ]
   },
@@ -2550,7 +2550,7 @@
     "preferred_prefix": "ctd.gene",
     "uri_format": "http://ctdbase.org/detail.go?type=gene&acc=$1",
     "prefix": "ctd.gene",
-    "all_prefixes": [
+    "synonyms": [
       "ctd.gene"
     ]
   },
@@ -2561,7 +2561,7 @@
     "preferred_prefix": "CTENO",
     "uri_format": "http://purl.obolibrary.org/obo/CTENO_$1",
     "prefix": "cteno",
-    "all_prefixes": [
+    "synonyms": [
       "cteno"
     ]
   },
@@ -2571,7 +2571,7 @@
     "preferred_prefix": "CTO",
     "uri_format": "http://purl.obolibrary.org/obo/CTO_$1",
     "prefix": "cto",
-    "all_prefixes": [
+    "synonyms": [
       "cto"
     ]
   },
@@ -2583,7 +2583,7 @@
     "preferred_prefix": "cubedb",
     "uri_format": "http://epsf.bmad.bii.a-star.edu.sg/cube/db/data/$1/",
     "prefix": "cubedb",
-    "all_prefixes": [
+    "synonyms": [
       "cubedb"
     ]
   },
@@ -2593,7 +2593,7 @@
     "preferred_prefix": "CVDO",
     "uri_format": "http://purl.obolibrary.org/obo/CVDO_$1",
     "prefix": "cvdo",
-    "all_prefixes": [
+    "synonyms": [
       "cvdo"
     ]
   },
@@ -2604,7 +2604,7 @@
     "preferred_prefix": "d1id",
     "uri_format": "https://cn.dataone.org/cn/v2/resolve/{$1}",
     "prefix": "d1id",
-    "all_prefixes": [
+    "synonyms": [
       "d1id"
     ]
   },
@@ -2615,7 +2615,7 @@
     "preferred_prefix": "dailymed",
     "uri_format": "https://dailymed.nlm.nih.gov/dailymed/drugInfo.cfm?setid=$1",
     "prefix": "dailymed",
-    "all_prefixes": [
+    "synonyms": [
       "dailymed"
     ]
   },
@@ -2626,7 +2626,7 @@
     "preferred_prefix": "dandi",
     "uri_format": "https://dandiarchive.org/dandiset/$1",
     "prefix": "dandi",
-    "all_prefixes": [
+    "synonyms": [
       "dandi"
     ]
   },
@@ -2637,7 +2637,7 @@
     "preferred_prefix": "darc",
     "uri_format": "http://darcsite.genzentrum.lmu.de/darc/view.php?id=$1",
     "prefix": "darc",
-    "all_prefixes": [
+    "synonyms": [
       "darc"
     ]
   },
@@ -2648,7 +2648,7 @@
     "preferred_prefix": "dashr",
     "uri_format": "http://lisanwanglab.org/DASHR/entry/$1",
     "prefix": "dashr",
-    "all_prefixes": [
+    "synonyms": [
       "dashr"
     ]
   },
@@ -2659,7 +2659,7 @@
     "preferred_prefix": "dashr.expression",
     "uri_format": "https://dashr1.lisanwanglab.org/entry/hsa-mir-200a#$1#exprPerTissueTable",
     "prefix": "dashr.expression",
-    "all_prefixes": [
+    "synonyms": [
       "dashr.expression"
     ]
   },
@@ -2670,7 +2670,7 @@
     "preferred_prefix": "datanator.gene",
     "uri_format": "https://www.datanator.info/gene/$1",
     "prefix": "datanator.gene",
-    "all_prefixes": [
+    "synonyms": [
       "datanator.gene"
     ]
   },
@@ -2681,7 +2681,7 @@
     "preferred_prefix": "datanator.metabolite",
     "uri_format": "https://www.datanator.info/metabolite/$1",
     "prefix": "datanator.metabolite",
-    "all_prefixes": [
+    "synonyms": [
       "datanator.metabolite"
     ]
   },
@@ -2692,7 +2692,7 @@
     "preferred_prefix": "datanator.reaction",
     "uri_format": "https://datanator.info/reaction/$1",
     "prefix": "datanator.reaction",
-    "all_prefixes": [
+    "synonyms": [
       "datanator.reaction"
     ]
   },
@@ -2704,7 +2704,7 @@
     "preferred_prefix": "datf",
     "uri_format": "http://planttfdb.cbi.pku.edu.cn/tf.php?sp=Ath&did=$1",
     "prefix": "datf",
-    "all_prefixes": [
+    "synonyms": [
       "datf"
     ]
   },
@@ -2715,7 +2715,7 @@
     "preferred_prefix": "dbd",
     "uri_format": "http://www.transcriptionfactor.org/index.cgi?Search/Domain+domain:$1+cat:DBD",
     "prefix": "dbd",
-    "all_prefixes": [
+    "synonyms": [
       "dbd"
     ]
   },
@@ -2726,7 +2726,7 @@
     "preferred_prefix": "dbest",
     "uri_format": "https://www.ncbi.nlm.nih.gov/nucest/$1",
     "prefix": "dbest",
-    "all_prefixes": [
+    "synonyms": [
       "dbest"
     ]
   },
@@ -2737,7 +2737,7 @@
     "preferred_prefix": "dbg2introns",
     "uri_format": "http://webapps2.ucalgary.ca/~groupii/cgi-bin/intron.cgi?name=$1",
     "prefix": "dbg2introns",
-    "all_prefixes": [
+    "synonyms": [
       "dbg2introns"
     ]
   },
@@ -2748,7 +2748,7 @@
     "preferred_prefix": "dbgap",
     "uri_format": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=$1",
     "prefix": "dbgap",
-    "all_prefixes": [
+    "synonyms": [
       "dbgap"
     ]
   },
@@ -2759,7 +2759,7 @@
     "preferred_prefix": "dbprobe",
     "uri_format": "https://www.ncbi.nlm.nih.gov/probe/?term=$1",
     "prefix": "dbprobe",
-    "all_prefixes": [
+    "synonyms": [
       "dbprobe"
     ]
   },
@@ -2770,7 +2770,7 @@
     "preferred_prefix": "dbsnp",
     "uri_format": "https://www.ncbi.nlm.nih.gov/snp/$1",
     "prefix": "dbsnp",
-    "all_prefixes": [
+    "synonyms": [
       "dbsnp"
     ]
   },
@@ -2781,7 +2781,7 @@
     "preferred_prefix": "dc",
     "uri_format": "http://purl.org/dc/elements/1.1/$1",
     "prefix": "dc",
-    "all_prefixes": [
+    "synonyms": [
       "dc"
     ]
   },
@@ -2791,7 +2791,7 @@
     "preferred_prefix": "DC_CL",
     "uri_format": "http://purl.obolibrary.org/obo/DC_CL_$1",
     "prefix": "dc_cl",
-    "all_prefixes": [
+    "synonyms": [
       "dc_cl"
     ]
   },
@@ -2801,7 +2801,7 @@
     "preferred_prefix": "dcat",
     "uri_format": "http://www.w3.org/ns/dcat#$1",
     "prefix": "dcat",
-    "all_prefixes": [
+    "synonyms": [
       "dcat"
     ]
   },
@@ -2811,7 +2811,7 @@
     "preferred_prefix": "dcterms",
     "uri_format": "https://dublincore.org/specifications/dublin-core/dcmi-terms/#$1",
     "prefix": "dcterms",
-    "all_prefixes": [
+    "synonyms": [
       "dc.terms",
       "dcterms"
     ]
@@ -2822,7 +2822,7 @@
     "preferred_prefix": "dctypes",
     "uri_format": "http://purl.org/dc/dcmitype/$1",
     "prefix": "dctypes",
-    "all_prefixes": [
+    "synonyms": [
       "dctypes"
     ]
   },
@@ -2833,7 +2833,7 @@
     "preferred_prefix": "DDANAT",
     "uri_format": "http://purl.obolibrary.org/obo/DDANAT_$1",
     "prefix": "ddanat",
-    "all_prefixes": [
+    "synonyms": [
       "ddanat"
     ]
   },
@@ -2844,7 +2844,7 @@
     "preferred_prefix": "DDPHENO",
     "uri_format": "http://purl.obolibrary.org/obo/DDPHENO_$1",
     "prefix": "ddpheno",
-    "all_prefixes": [
+    "synonyms": [
       "ddpheno"
     ]
   },
@@ -2855,7 +2855,7 @@
     "preferred_prefix": "degradome",
     "uri_format": "http://degradome.uniovi.es/cgi-bin/protease/$1",
     "prefix": "degradome",
-    "all_prefixes": [
+    "synonyms": [
       "degradome"
     ]
   },
@@ -2866,7 +2866,7 @@
     "preferred_prefix": "depmap",
     "uri_format": "https://depmap.org/portal/cell_line/$1",
     "prefix": "depmap",
-    "all_prefixes": [
+    "synonyms": [
       "depmap"
     ]
   },
@@ -2877,7 +2877,7 @@
     "preferred_prefix": "depod",
     "uri_format": "http://www.depod.bioss.uni-freiburg.de/showp.php?gene=$1",
     "prefix": "depod",
-    "all_prefixes": [
+    "synonyms": [
       "depod"
     ]
   },
@@ -2888,7 +2888,7 @@
     "preferred_prefix": "dev.ga4ghdos",
     "uri_format": "https://dos-gdc.ucsc-cgp-dev.org/ga4gh/dos/v1/dataobjects/$1",
     "prefix": "dev.ga4ghdos",
-    "all_prefixes": [
+    "synonyms": [
       "dev.ga4ghdos"
     ]
   },
@@ -2899,7 +2899,7 @@
     "preferred_prefix": "dg.4503",
     "uri_format": "https://gen3.biodatacatalyst.nhlbi.nih.gov/ga4gh/drs/v1/objects/$1",
     "prefix": "dg.4503",
-    "all_prefixes": [
+    "synonyms": [
       "dg.4503"
     ]
   },
@@ -2910,7 +2910,7 @@
     "preferred_prefix": "dg.4dfc",
     "uri_format": "https://nci-crdc.datacommons.io/ga4gh/drs/v1/objects/$1",
     "prefix": "dg.4dfc",
-    "all_prefixes": [
+    "synonyms": [
       "dg.4dfc"
     ]
   },
@@ -2921,7 +2921,7 @@
     "preferred_prefix": "dg.6vts",
     "uri_format": "https://jcoin.datacommons.io/ga4gh/drs/v1/objects/$1",
     "prefix": "dg.6vts",
-    "all_prefixes": [
+    "synonyms": [
       "dg.6vts"
     ]
   },
@@ -2932,7 +2932,7 @@
     "preferred_prefix": "dg.anv0",
     "uri_format": "https://gen3.theanvil.io/ga4gh/drs/v1/objects/$1",
     "prefix": "dg.anv0",
-    "all_prefixes": [
+    "synonyms": [
       "dg.anv0"
     ]
   },
@@ -2943,7 +2943,7 @@
     "preferred_prefix": "dg.f82a1a",
     "uri_format": "https://data.kidsfirstdrc.org/ga4gh/drs/v1/objects/$1",
     "prefix": "dg.f82a1a",
-    "all_prefixes": [
+    "synonyms": [
       "dg.f82a1a"
     ]
   },
@@ -2953,7 +2953,7 @@
     "preferred_prefix": "dictybase",
     "uri_format": "http://dictybase.org/gene/$1",
     "prefix": "dictybase",
-    "all_prefixes": [
+    "synonyms": [
       "dictybase"
     ]
   },
@@ -2964,7 +2964,7 @@
     "preferred_prefix": "dictybase.est",
     "uri_format": "http://dictybase.org/db/cgi-bin/feature_page.pl?primary_id=$1",
     "prefix": "dictybase.est",
-    "all_prefixes": [
+    "synonyms": [
       "dictybase.est"
     ]
   },
@@ -2975,7 +2975,7 @@
     "preferred_prefix": "dictybase.gene",
     "uri_format": "http://dictybase.org/gene/$1",
     "prefix": "dictybase.gene",
-    "all_prefixes": [
+    "synonyms": [
       "dictybase.gene"
     ]
   },
@@ -2986,7 +2986,7 @@
     "preferred_prefix": "did",
     "uri_format": "https://uniresolver.io/#did:$1",
     "prefix": "did",
-    "all_prefixes": [
+    "synonyms": [
       "did"
     ]
   },
@@ -2996,7 +2996,7 @@
     "preferred_prefix": "DIDEO",
     "uri_format": "http://purl.obolibrary.org/obo/DIDEO_$1",
     "prefix": "dideo",
-    "all_prefixes": [
+    "synonyms": [
       "dideo"
     ]
   },
@@ -3006,7 +3006,7 @@
     "preferred_prefix": "DINTO",
     "uri_format": "http://purl.obolibrary.org/obo/DINTO_$1",
     "prefix": "dinto",
-    "all_prefixes": [
+    "synonyms": [
       "dinto"
     ]
   },
@@ -3017,7 +3017,7 @@
     "preferred_prefix": "dip",
     "uri_format": "https://dip.doe-mbi.ucla.edu/dip/DIPview.cgi?ID=$1",
     "prefix": "dip",
-    "all_prefixes": [
+    "synonyms": [
       "dip"
     ]
   },
@@ -3028,7 +3028,7 @@
     "preferred_prefix": "disprot",
     "uri_format": "https://disprot.org/$1",
     "prefix": "disprot",
-    "all_prefixes": [
+    "synonyms": [
       "disprot"
     ]
   },
@@ -3039,7 +3039,7 @@
     "preferred_prefix": "disprot.region",
     "uri_format": "https://www.disprot.org/$1",
     "prefix": "disprot.region",
-    "all_prefixes": [
+    "synonyms": [
       "disprot.region"
     ]
   },
@@ -3050,7 +3050,7 @@
     "preferred_prefix": "dlxb",
     "uri_format": "https://doulix.com/biomodules/$1",
     "prefix": "dlxb",
-    "all_prefixes": [
+    "synonyms": [
       "dlxb"
     ]
   },
@@ -3061,7 +3061,7 @@
     "preferred_prefix": "dlxc",
     "uri_format": "https://doulix.com/constructs/$1",
     "prefix": "dlxc",
-    "all_prefixes": [
+    "synonyms": [
       "dlxc"
     ]
   },
@@ -3072,7 +3072,7 @@
     "preferred_prefix": "doi",
     "uri_format": "https://doi.org/$1",
     "prefix": "doi",
-    "all_prefixes": [
+    "synonyms": [
       "doi"
     ]
   },
@@ -3083,7 +3083,7 @@
     "preferred_prefix": "DOID",
     "uri_format": "https://www.ebi.ac.uk/ols/ontologies/doid/terms?obo_id=DOID:$1",
     "prefix": "doid",
-    "all_prefixes": [
+    "synonyms": [
       "do",
       "doid"
     ]
@@ -3095,7 +3095,7 @@
     "preferred_prefix": "dommino",
     "uri_format": "http://orion.rnet.missouri.edu/~nz953/DOMMINO/index.php/result/show_network/$1",
     "prefix": "dommino",
-    "all_prefixes": [
+    "synonyms": [
       "dommino"
     ]
   },
@@ -3106,7 +3106,7 @@
     "preferred_prefix": "door",
     "uri_format": "http://csbl.bmb.uga.edu/DOOR/operon.php?id=$1",
     "prefix": "door",
-    "all_prefixes": [
+    "synonyms": [
       "door"
     ]
   },
@@ -3117,7 +3117,7 @@
     "preferred_prefix": "doqcs.model",
     "uri_format": "http://doqcs.ncbs.res.in/template.php?&y=accessiondetails&an=$1",
     "prefix": "doqcs.model",
-    "all_prefixes": [
+    "synonyms": [
       "doqcs.model"
     ]
   },
@@ -3128,7 +3128,7 @@
     "preferred_prefix": "doqcs.pathway",
     "uri_format": "http://doqcs.ncbs.res.in/template.php?&y=pathwaydetails&pn=$1",
     "prefix": "doqcs.pathway",
-    "all_prefixes": [
+    "synonyms": [
       "doqcs.pathway"
     ]
   },
@@ -3137,7 +3137,7 @@
     "preferred_prefix": "DPO",
     "uri_format": "http://purl.obolibrary.org/obo/FBcv_$1",
     "prefix": "dpo",
-    "all_prefixes": [
+    "synonyms": [
       "dpo"
     ]
   },
@@ -3148,7 +3148,7 @@
     "preferred_prefix": "dpv",
     "uri_format": "http://www.dpvweb.net/dpv/showdpv.php?dpvno=$1",
     "prefix": "dpv",
-    "all_prefixes": [
+    "synonyms": [
       "dpv"
     ]
   },
@@ -3160,7 +3160,7 @@
     "preferred_prefix": "dragondb.allele",
     "uri_format": "http://antirrhinum.net/cgi-bin/ace/generic/tree/DragonDB?name=$1&amp;class=Allele",
     "prefix": "dragondb.allele",
-    "all_prefixes": [
+    "synonyms": [
       "dragondb.allele"
     ]
   },
@@ -3172,7 +3172,7 @@
     "preferred_prefix": "dragondb.dna",
     "uri_format": "http://antirrhinum.net/cgi-bin/ace/generic/tree/DragonDB?name=$1;class=DNA",
     "prefix": "dragondb.dna",
-    "all_prefixes": [
+    "synonyms": [
       "dragondb.dna"
     ]
   },
@@ -3184,7 +3184,7 @@
     "preferred_prefix": "dragondb.locus",
     "uri_format": "http://antirrhinum.net/cgi-bin/ace/generic/tree/DragonDB?name=$1&amp;class=Locus",
     "prefix": "dragondb.locus",
-    "all_prefixes": [
+    "synonyms": [
       "dragondb.locus"
     ]
   },
@@ -3196,7 +3196,7 @@
     "preferred_prefix": "dragondb.protein",
     "uri_format": "http://antirrhinum.net/cgi-bin/ace/generic/tree/DragonDB?name=$1;class=Peptide",
     "prefix": "dragondb.protein",
-    "all_prefixes": [
+    "synonyms": [
       "dragondb.protein"
     ]
   },
@@ -3206,7 +3206,7 @@
     "preferred_prefix": "DRON",
     "uri_format": "http://purl.obolibrary.org/obo/DRON_$1",
     "prefix": "dron",
-    "all_prefixes": [
+    "synonyms": [
       "dron"
     ]
   },
@@ -3217,7 +3217,7 @@
     "preferred_prefix": "drsc",
     "uri_format": "http://www.flyrnai.org/cgi-bin/RNAi_gene_lookup_public.pl?gname=$1",
     "prefix": "drsc",
-    "all_prefixes": [
+    "synonyms": [
       "drsc"
     ]
   },
@@ -3228,7 +3228,7 @@
     "preferred_prefix": "drugbank",
     "uri_format": "http://www.drugbank.ca/drugs/$1",
     "prefix": "drugbank",
-    "all_prefixes": [
+    "synonyms": [
       "drugbank",
       "drugbank_id"
     ]
@@ -3240,7 +3240,7 @@
     "preferred_prefix": "drugbank.salt",
     "uri_format": "https://go.drugbank.com/salts/$1",
     "prefix": "drugbank.salt",
-    "all_prefixes": [
+    "synonyms": [
       "drugbank.salt",
       "drugbank.target"
     ]
@@ -3252,7 +3252,7 @@
     "preferred_prefix": "drugbankv4.target",
     "uri_format": "http://www.drugbank.ca/biodb/bio_entities/$1",
     "prefix": "drugbankv4.target",
-    "all_prefixes": [
+    "synonyms": [
       "drugbankv4.target"
     ]
   },
@@ -3262,7 +3262,7 @@
     "preferred_prefix": "drugcentral",
     "uri_format": "http://drugcentral.org/drugcard/$1",
     "prefix": "drugcentral",
-    "all_prefixes": [
+    "synonyms": [
       "drug_central",
       "drugcentral"
     ]
@@ -3273,7 +3273,7 @@
     "preferred_prefix": "dsmz",
     "uri_format": "https://www.dsmz.de/collection/catalogue/details/culture/$1",
     "prefix": "dsmz",
-    "all_prefixes": [
+    "synonyms": [
       "dsmz"
     ]
   },
@@ -3283,7 +3283,7 @@
     "preferred_prefix": "DUO",
     "uri_format": "http://purl.obolibrary.org/obo/DUO_$1",
     "prefix": "duo",
-    "all_prefixes": [
+    "synonyms": [
       "duo"
     ]
   },
@@ -3293,7 +3293,7 @@
     "preferred_prefix": "eaglei",
     "uri_format": "http://hawaii.eagle-i.net/i/$1",
     "prefix": "eaglei",
-    "all_prefixes": [
+    "synonyms": [
       "eaglei"
     ]
   },
@@ -3303,7 +3303,7 @@
     "preferred_prefix": "ecacc",
     "uri_format": "https://www.phe-culturecollections.org.uk/products/celllines/generalcell/detail.jsp?collection=ecacc_gc&refId=$1",
     "prefix": "ecacc",
-    "all_prefixes": [
+    "synonyms": [
       "ecacc"
     ]
   },
@@ -3313,7 +3313,7 @@
     "preferred_prefix": "ECAO",
     "uri_format": "http://purl.obolibrary.org/obo/ECAO_$1",
     "prefix": "ecao",
-    "all_prefixes": [
+    "synonyms": [
       "ecao"
     ]
   },
@@ -3324,7 +3324,7 @@
     "preferred_prefix": "eccode",
     "uri_format": "https://www.ebi.ac.uk/intenz/query?cmd=SearchEC&ec=$1",
     "prefix": "eccode",
-    "all_prefixes": [
+    "synonyms": [
       "ec",
       "ec-code",
       "ec_code",
@@ -3339,7 +3339,7 @@
     "preferred_prefix": "echobase",
     "uri_format": "http://www.york.ac.uk/res/thomas/Gene.cfm?recordID=$1",
     "prefix": "echobase",
-    "all_prefixes": [
+    "synonyms": [
       "echobase"
     ]
   },
@@ -3350,7 +3350,7 @@
     "preferred_prefix": "ecmdb",
     "uri_format": "http://ecmdb.ca/compounds/$1",
     "prefix": "ecmdb",
-    "all_prefixes": [
+    "synonyms": [
       "ecmdb"
     ]
   },
@@ -3361,7 +3361,7 @@
     "preferred_prefix": "ECO",
     "uri_format": "https://www.ebi.ac.uk/ols/ontologies/eco/terms?obo_id=ECO:$1",
     "prefix": "eco",
-    "all_prefixes": [
+    "synonyms": [
       "eco"
     ]
   },
@@ -3372,7 +3372,7 @@
     "preferred_prefix": "ECOCORE",
     "uri_format": "http://purl.obolibrary.org/obo/ECOCORE_$1",
     "prefix": "ecocore",
-    "all_prefixes": [
+    "synonyms": [
       "ecocore"
     ]
   },
@@ -3382,7 +3382,7 @@
     "preferred_prefix": "ecocyc",
     "uri_format": "https://biocyc.org/gene?id=$1",
     "prefix": "ecocyc",
-    "all_prefixes": [
+    "synonyms": [
       "ecocyc"
     ]
   },
@@ -3393,7 +3393,7 @@
     "preferred_prefix": "ecogene",
     "uri_format": "http://www.ecogene.org/gene/$1",
     "prefix": "ecogene",
-    "all_prefixes": [
+    "synonyms": [
       "ecogene"
     ]
   },
@@ -3404,7 +3404,7 @@
     "preferred_prefix": "ecoliwiki",
     "uri_format": "http://ecoliwiki.net/colipedia/index.php/$1:Gene",
     "prefix": "ecoliwiki",
-    "all_prefixes": [
+    "synonyms": [
       "ecoliwiki"
     ]
   },
@@ -3415,7 +3415,7 @@
     "preferred_prefix": "ECTO",
     "uri_format": "http://purl.obolibrary.org/obo/ECTO_$1",
     "prefix": "ecto",
-    "all_prefixes": [
+    "synonyms": [
       "ecto"
     ]
   },
@@ -3426,7 +3426,7 @@
     "preferred_prefix": "ecyano.entity",
     "uri_format": "https://www.e-cyanobacterium.org/bcs/entity/$1",
     "prefix": "ecyano.entity",
-    "all_prefixes": [
+    "synonyms": [
       "ecyano.entity"
     ]
   },
@@ -3437,7 +3437,7 @@
     "preferred_prefix": "ecyano.experiment",
     "uri_format": "https://www.e-cyanobacterium.org/experiments-repository/?action=detail&id=$1",
     "prefix": "ecyano.experiment",
-    "all_prefixes": [
+    "synonyms": [
       "ecyano.experiment"
     ]
   },
@@ -3448,7 +3448,7 @@
     "preferred_prefix": "ecyano.model",
     "uri_format": "https://e-cyanobacterium.org/models/model/$1",
     "prefix": "ecyano.model",
-    "all_prefixes": [
+    "synonyms": [
       "ecyano.model"
     ]
   },
@@ -3459,7 +3459,7 @@
     "preferred_prefix": "ecyano.rule",
     "uri_format": "https://e-cyanobacterium.org/bcs/rule/$1",
     "prefix": "ecyano.rule",
-    "all_prefixes": [
+    "synonyms": [
       "ecyano.rule"
     ]
   },
@@ -3470,7 +3470,7 @@
     "preferred_prefix": "edam",
     "uri_format": "http://purl.bioontology.org/ontology/EDAM/$1",
     "prefix": "edam",
-    "all_prefixes": [
+    "synonyms": [
       "edam"
     ]
   },
@@ -3481,7 +3481,7 @@
     "preferred_prefix": "EFO",
     "uri_format": "http://www.ebi.ac.uk/efo/EFO_$1",
     "prefix": "efo",
-    "all_prefixes": [
+    "synonyms": [
       "efo"
     ]
   },
@@ -3492,7 +3492,7 @@
     "preferred_prefix": "ega.dataset",
     "uri_format": "https://www.ebi.ac.uk/ega/datasets/$1",
     "prefix": "ega.dataset",
-    "all_prefixes": [
+    "synonyms": [
       "ega.dataset"
     ]
   },
@@ -3503,7 +3503,7 @@
     "preferred_prefix": "ega.study",
     "uri_format": "https://www.ebi.ac.uk/ega/studies/$1",
     "prefix": "ega.study",
-    "all_prefixes": [
+    "synonyms": [
       "ega.study"
     ]
   },
@@ -3514,7 +3514,7 @@
     "preferred_prefix": "eggnog",
     "uri_format": "http://eggnog.embl.de/version_3.0/cgi/search.py?search_term_0=$1",
     "prefix": "eggnog",
-    "all_prefixes": [
+    "synonyms": [
       "eggnog"
     ]
   },
@@ -3524,7 +3524,7 @@
     "preferred_prefix": "EHDA",
     "uri_format": "http://purl.obolibrary.org/obo/EHDA_$1",
     "prefix": "ehda",
-    "all_prefixes": [
+    "synonyms": [
       "ehda"
     ]
   },
@@ -3534,7 +3534,7 @@
     "preferred_prefix": "EHDAA",
     "uri_format": "http://purl.obolibrary.org/obo/EHDAA_$1",
     "prefix": "ehdaa",
-    "all_prefixes": [
+    "synonyms": [
       "ehdaa"
     ]
   },
@@ -3545,7 +3545,7 @@
     "preferred_prefix": "EHDAA2",
     "uri_format": "http://purl.obolibrary.org/obo/EHDAA2_$1",
     "prefix": "ehdaa2",
-    "all_prefixes": [
+    "synonyms": [
       "ehdaa2",
       "ehdaa2_retired",
       "hdaa2",
@@ -3559,7 +3559,7 @@
     "preferred_prefix": "elm",
     "uri_format": "http://elm.eu.org/elms/elmPages/$1.html",
     "prefix": "elm",
-    "all_prefixes": [
+    "synonyms": [
       "elm"
     ]
   },
@@ -3569,7 +3569,7 @@
     "preferred_prefix": "EMAP",
     "uri_format": "http://purl.obolibrary.org/obo/EMAP_$1",
     "prefix": "emap",
-    "all_prefixes": [
+    "synonyms": [
       "emap"
     ]
   },
@@ -3580,7 +3580,7 @@
     "preferred_prefix": "EMAPA",
     "uri_format": "http://www.informatics.jax.org/vocab/gxd/anatomy/EMAPA:$1",
     "prefix": "emapa",
-    "all_prefixes": [
+    "synonyms": [
       "emapa",
       "emapa_retired"
     ]
@@ -3592,7 +3592,7 @@
     "preferred_prefix": "emdb",
     "uri_format": "https://www.ebi.ac.uk/pdbe/entry/emdb/$1",
     "prefix": "emdb",
-    "all_prefixes": [
+    "synonyms": [
       "emdb"
     ]
   },
@@ -3603,7 +3603,7 @@
     "preferred_prefix": "emolecules",
     "uri_format": "https://reaxys.emolecules.com/cgi-bin/more?vid=$1",
     "prefix": "emolecules",
-    "all_prefixes": [
+    "synonyms": [
       "emolecules"
     ]
   },
@@ -3613,7 +3613,7 @@
     "preferred_prefix": "empiar",
     "uri_format": "https://www.ebi.ac.uk/pdbe/emdb/empiar/entry/$1",
     "prefix": "empiar",
-    "all_prefixes": [
+    "synonyms": [
       "empiar"
     ]
   },
@@ -3624,7 +3624,7 @@
     "preferred_prefix": "ena.embl",
     "uri_format": "https://www.ebi.ac.uk/ena/browser/view/$1",
     "prefix": "ena.embl",
-    "all_prefixes": [
+    "synonyms": [
       "ena",
       "ena.embl"
     ]
@@ -3636,7 +3636,7 @@
     "preferred_prefix": "encode",
     "uri_format": "https://www.encodeproject.org/$1",
     "prefix": "encode",
-    "all_prefixes": [
+    "synonyms": [
       "encode"
     ]
   },
@@ -3647,7 +3647,7 @@
     "preferred_prefix": "ensembl",
     "uri_format": "https://www.ensembl.org/id/$1",
     "prefix": "ensembl",
-    "all_prefixes": [
+    "synonyms": [
       "ensembl"
     ]
   },
@@ -3658,7 +3658,7 @@
     "preferred_prefix": "ensembl.bacteria",
     "uri_format": "https://bacteria.ensembl.org/id/$1",
     "prefix": "ensembl.bacteria",
-    "all_prefixes": [
+    "synonyms": [
       "ensembl.bacteria"
     ]
   },
@@ -3669,7 +3669,7 @@
     "preferred_prefix": "ensembl.fungi",
     "uri_format": "https://fungi.ensembl.org/id/$1",
     "prefix": "ensembl.fungi",
-    "all_prefixes": [
+    "synonyms": [
       "ensembl.fungi"
     ]
   },
@@ -3680,7 +3680,7 @@
     "preferred_prefix": "ensembl.metazoa",
     "uri_format": "https://metazoa.ensembl.org/id/$1",
     "prefix": "ensembl.metazoa",
-    "all_prefixes": [
+    "synonyms": [
       "ensembl.metazoa"
     ]
   },
@@ -3691,7 +3691,7 @@
     "preferred_prefix": "ensembl.plant",
     "uri_format": "https://plants.ensembl.org/id/$1",
     "prefix": "ensembl.plant",
-    "all_prefixes": [
+    "synonyms": [
       "ensembl.plant"
     ]
   },
@@ -3702,7 +3702,7 @@
     "preferred_prefix": "ensembl.protist",
     "uri_format": "https://protists.ensembl.org/id/$1",
     "prefix": "ensembl.protist",
-    "all_prefixes": [
+    "synonyms": [
       "ensembl.protist"
     ]
   },
@@ -3713,7 +3713,7 @@
     "preferred_prefix": "envipath",
     "uri_format": "https://envipath.org/package/$1",
     "prefix": "envipath",
-    "all_prefixes": [
+    "synonyms": [
       "envipath"
     ]
   },
@@ -3724,7 +3724,7 @@
     "preferred_prefix": "ENVO",
     "uri_format": "https://www.ebi.ac.uk/ols/ontologies/envo/terms?obo_id=ENVO:$1",
     "prefix": "envo",
-    "all_prefixes": [
+    "synonyms": [
       "envo"
     ]
   },
@@ -3734,7 +3734,7 @@
     "preferred_prefix": "enzo",
     "uri_format": "https://www.enzolifesciences.com/$1",
     "prefix": "enzo",
-    "all_prefixes": [
+    "synonyms": [
       "enzo"
     ]
   },
@@ -3745,7 +3745,7 @@
     "preferred_prefix": "epd",
     "uri_format": "http://epd.vital-it.ch/cgi-bin/query_result.pl?out_format=NICE&Entry_0=$1",
     "prefix": "epd",
-    "all_prefixes": [
+    "synonyms": [
       "epd"
     ]
   },
@@ -3755,7 +3755,7 @@
     "preferred_prefix": "EPO",
     "uri_format": "http://purl.obolibrary.org/obo/EPO_$1",
     "prefix": "epo",
-    "all_prefixes": [
+    "synonyms": [
       "epo"
     ]
   },
@@ -3766,7 +3766,7 @@
     "preferred_prefix": "erm",
     "uri_format": "https://nanocommons.github.io/identifiers/registry#$1",
     "prefix": "erm",
-    "all_prefixes": [
+    "synonyms": [
       "erm"
     ]
   },
@@ -3776,7 +3776,7 @@
     "preferred_prefix": "ERO",
     "uri_format": "http://purl.obolibrary.org/obo/ERO_$1",
     "prefix": "ero",
-    "all_prefixes": [
+    "synonyms": [
       "ero"
     ]
   },
@@ -3787,7 +3787,7 @@
     "preferred_prefix": "erv",
     "uri_format": "https://herv.img.cas.cz/s/$1",
     "prefix": "erv",
-    "all_prefixes": [
+    "synonyms": [
       "erv"
     ]
   },
@@ -3798,7 +3798,7 @@
     "preferred_prefix": "eu89h",
     "uri_format": "http://data.europa.eu/89h/$1",
     "prefix": "eu89h",
-    "all_prefixes": [
+    "synonyms": [
       "eu89h"
     ]
   },
@@ -3809,7 +3809,7 @@
     "preferred_prefix": "euclinicaltrials",
     "uri_format": "https://www.clinicaltrialsregister.eu/ctr-search/search?query=$1",
     "prefix": "euclinicaltrials",
-    "all_prefixes": [
+    "synonyms": [
       "euclinicaltrials"
     ]
   },
@@ -3819,7 +3819,7 @@
     "preferred_prefix": "EUPATH",
     "uri_format": "http://purl.obolibrary.org/obo/EUPATH_$1",
     "prefix": "eupath",
-    "all_prefixes": [
+    "synonyms": [
       "eupath"
     ]
   },
@@ -3829,7 +3829,7 @@
     "preferred_prefix": "EV",
     "uri_format": "http://purl.obolibrary.org/obo/EV_$1",
     "prefix": "ev",
-    "all_prefixes": [
+    "synonyms": [
       "ev"
     ]
   },
@@ -3840,7 +3840,7 @@
     "preferred_prefix": "exac.gene",
     "uri_format": "http://exac.broadinstitute.org/gene/$1",
     "prefix": "exac.gene",
-    "all_prefixes": [
+    "synonyms": [
       "exac.gene"
     ]
   },
@@ -3851,7 +3851,7 @@
     "preferred_prefix": "exac.transcript",
     "uri_format": "http://exac.broadinstitute.org/transcript/$1",
     "prefix": "exac.transcript",
-    "all_prefixes": [
+    "synonyms": [
       "exac.transcript"
     ]
   },
@@ -3862,7 +3862,7 @@
     "preferred_prefix": "exac.variant",
     "uri_format": "http://exac.broadinstitute.org/variant/$1",
     "prefix": "exac.variant",
-    "all_prefixes": [
+    "synonyms": [
       "exac.variant"
     ]
   },
@@ -3873,7 +3873,7 @@
     "preferred_prefix": "ExO",
     "uri_format": "http://purl.obolibrary.org/obo/EXO_$1",
     "prefix": "exo",
-    "all_prefixes": [
+    "synonyms": [
       "exo"
     ]
   },
@@ -3884,7 +3884,7 @@
     "preferred_prefix": "facebase",
     "uri_format": "https://www.facebase.org/data/record/#1/isa:dataset/accession=$1",
     "prefix": "facebase",
-    "all_prefixes": [
+    "synonyms": [
       "facebase"
     ]
   },
@@ -3895,7 +3895,7 @@
     "preferred_prefix": "fairsharing",
     "uri_format": "https://fairsharing.org/$1",
     "prefix": "fairsharing",
-    "all_prefixes": [
+    "synonyms": [
       "fairsharing"
     ]
   },
@@ -3905,7 +3905,7 @@
     "preferred_prefix": "faldo",
     "uri_format": "http://biohackathon.org/resource/faldo#$1",
     "prefix": "faldo",
-    "all_prefixes": [
+    "synonyms": [
       "faldo"
     ]
   },
@@ -3916,7 +3916,7 @@
     "preferred_prefix": "FAO",
     "uri_format": "http://purl.obolibrary.org/obo/FAO_$1",
     "prefix": "fao",
-    "all_prefixes": [
+    "synonyms": [
       "fao"
     ]
   },
@@ -3927,7 +3927,7 @@
     "preferred_prefix": "FBbi",
     "uri_format": "http://purl.obolibrary.org/obo/FBbi_$1",
     "prefix": "fbbi",
-    "all_prefixes": [
+    "synonyms": [
       "fbbi"
     ]
   },
@@ -3937,7 +3937,7 @@
     "preferred_prefix": "FBbt",
     "uri_format": "https://flybase.org/cgi-bin/cvreport.pl?id=FBbt:$1",
     "prefix": "fbbt",
-    "all_prefixes": [
+    "synonyms": [
       "fbbt",
       "fbbt_root"
     ]
@@ -3949,7 +3949,7 @@
     "preferred_prefix": "FBcv",
     "uri_format": "http://purl.obolibrary.org/obo/FBcv_$1",
     "prefix": "fbcv",
-    "all_prefixes": [
+    "synonyms": [
       "fbcv"
     ]
   },
@@ -3960,7 +3960,7 @@
     "preferred_prefix": "FBdv",
     "uri_format": "http://purl.obolibrary.org/obo/FBdv_$1",
     "prefix": "fbdv",
-    "all_prefixes": [
+    "synonyms": [
       "fbdv"
     ]
   },
@@ -3972,7 +3972,7 @@
     "preferred_prefix": "fbol",
     "uri_format": "http://www.fungalbarcoding.org/BioloMICS.aspx?Table=Fungal barcodes&Rec=$1&Fields=All&ExactMatch=T",
     "prefix": "fbol",
-    "all_prefixes": [
+    "synonyms": [
       "fbol"
     ]
   },
@@ -3982,7 +3982,7 @@
     "preferred_prefix": "fbrf",
     "uri_format": "https://flybase.org/reports/FBrf$1",
     "prefix": "fbrf",
-    "all_prefixes": [
+    "synonyms": [
       "fbrf"
     ]
   },
@@ -3992,7 +3992,7 @@
     "preferred_prefix": "FBSP",
     "uri_format": "http://purl.obolibrary.org/obo/FBSP_$1",
     "prefix": "fbsp",
-    "all_prefixes": [
+    "synonyms": [
       "fbsp"
     ]
   },
@@ -4002,7 +4002,7 @@
     "preferred_prefix": "fbtc",
     "uri_format": "https://flybase.org/reports/FBtc$1",
     "prefix": "fbtc",
-    "all_prefixes": [
+    "synonyms": [
       "fbtc"
     ]
   },
@@ -4012,7 +4012,7 @@
     "preferred_prefix": "FIDEO",
     "uri_format": "http://purl.obolibrary.org/obo/FIDEO_$1",
     "prefix": "fideo",
-    "all_prefixes": [
+    "synonyms": [
       "fideo"
     ]
   },
@@ -4023,7 +4023,7 @@
     "preferred_prefix": "FIX",
     "uri_format": "http://purl.obolibrary.org/obo/FIX_$1",
     "prefix": "fix",
-    "all_prefixes": [
+    "synonyms": [
       "fix"
     ]
   },
@@ -4033,7 +4033,7 @@
     "preferred_prefix": "FLOPO",
     "uri_format": "http://purl.obolibrary.org/obo/FLOPO_$1",
     "prefix": "flopo",
-    "all_prefixes": [
+    "synonyms": [
       "flopo"
     ]
   },
@@ -4044,7 +4044,7 @@
     "preferred_prefix": "flowrepository",
     "uri_format": "https://flowrepository.org/id/$1",
     "prefix": "flowrepository",
-    "all_prefixes": [
+    "synonyms": [
       "flowrepository"
     ]
   },
@@ -4054,7 +4054,7 @@
     "preferred_prefix": "FLU",
     "uri_format": "http://purl.obolibrary.org/obo/FLU_$1",
     "prefix": "flu",
-    "all_prefixes": [
+    "synonyms": [
       "flu"
     ]
   },
@@ -4065,7 +4065,7 @@
     "preferred_prefix": "FlyBase",
     "uri_format": "https://flybase.org/reports/$1",
     "prefix": "flybase",
-    "all_prefixes": [
+    "synonyms": [
       "fb",
       "flybase"
     ]
@@ -4077,7 +4077,7 @@
     "preferred_prefix": "FMA",
     "uri_format": "https://www.ebi.ac.uk/ols/ontologies/fma/terms?obo_id=FMA:$1",
     "prefix": "fma",
-    "all_prefixes": [
+    "synonyms": [
       "fma",
       "fma_retired",
       "fmaid"
@@ -4089,7 +4089,7 @@
     "preferred_prefix": "foaf",
     "uri_format": "http://xmlns.com/foaf/0.1/$1",
     "prefix": "foaf",
-    "all_prefixes": [
+    "synonyms": [
       "foaf"
     ]
   },
@@ -4099,7 +4099,7 @@
     "preferred_prefix": "FOBI",
     "uri_format": "http://purl.obolibrary.org/obo/FOBI_$1",
     "prefix": "fobi",
-    "all_prefixes": [
+    "synonyms": [
       "fobi"
     ]
   },
@@ -4110,7 +4110,7 @@
     "preferred_prefix": "foodb.compound",
     "uri_format": "http://foodb.ca/compounds/$1",
     "prefix": "foodb.compound",
-    "all_prefixes": [
+    "synonyms": [
       "foodb",
       "foodb.compound"
     ]
@@ -4122,7 +4122,7 @@
     "preferred_prefix": "FOODON",
     "uri_format": "https://www.ebi.ac.uk/ols/ontologies/foodon/terms?obo_id=FOODON:$1",
     "prefix": "foodon",
-    "all_prefixes": [
+    "synonyms": [
       "foodon"
     ]
   },
@@ -4132,7 +4132,7 @@
     "preferred_prefix": "FOVT",
     "uri_format": "http://purl.obolibrary.org/obo/FOVT_$1",
     "prefix": "fovt",
-    "all_prefixes": [
+    "synonyms": [
       "fovt"
     ]
   },
@@ -4143,7 +4143,7 @@
     "preferred_prefix": "fplx",
     "uri_format": "https://sorgerlab.github.io/famplex/$1",
     "prefix": "fplx",
-    "all_prefixes": [
+    "synonyms": [
       "famplex",
       "fplx"
     ]
@@ -4155,7 +4155,7 @@
     "preferred_prefix": "fsnp",
     "uri_format": "http://compbio.cs.queensu.ca/cgi-bin/compbio/search/main.cgi?search_mode=id&amp;id_type=snp_id&amp;id_val=$1",
     "prefix": "fsnp",
-    "all_prefixes": [
+    "synonyms": [
       "fsnp"
     ]
   },
@@ -4166,7 +4166,7 @@
     "preferred_prefix": "funcbase.fly",
     "uri_format": "http://func.mshri.on.ca/fly/genes/list_functional_scores/$1",
     "prefix": "funcbase.fly",
-    "all_prefixes": [
+    "synonyms": [
       "funcbase.fly"
     ]
   },
@@ -4177,7 +4177,7 @@
     "preferred_prefix": "funcbase.human",
     "uri_format": "http://func.mshri.on.ca/human/genes/list_functional_scores/$1",
     "prefix": "funcbase.human",
-    "all_prefixes": [
+    "synonyms": [
       "funcbase.human"
     ]
   },
@@ -4188,7 +4188,7 @@
     "preferred_prefix": "funcbase.mouse",
     "uri_format": "http://func.mshri.on.ca/mouse/genes/list_functional_scores/$1",
     "prefix": "funcbase.mouse",
-    "all_prefixes": [
+    "synonyms": [
       "funcbase.mouse"
     ]
   },
@@ -4199,7 +4199,7 @@
     "preferred_prefix": "funcbase.yeast",
     "uri_format": "http://func.mshri.on.ca/yeast/genes/list_functional_scores/$1",
     "prefix": "funcbase.yeast",
-    "all_prefixes": [
+    "synonyms": [
       "funcbase.yeast"
     ]
   },
@@ -4210,7 +4210,7 @@
     "preferred_prefix": "funderregistry",
     "uri_format": "http://data.crossref.org/fundingdata/funder/10.13039/$1",
     "prefix": "funderregistry",
-    "all_prefixes": [
+    "synonyms": [
       "funderregistry"
     ]
   },
@@ -4221,7 +4221,7 @@
     "preferred_prefix": "fungidb",
     "uri_format": "https://fungidb.org/fungidb/app/record/gene/$1",
     "prefix": "fungidb",
-    "all_prefixes": [
+    "synonyms": [
       "fungidb"
     ]
   },
@@ -4232,7 +4232,7 @@
     "preferred_prefix": "FYPO",
     "uri_format": "http://purl.obolibrary.org/obo/FYPO_$1",
     "prefix": "fypo",
-    "all_prefixes": [
+    "synonyms": [
       "fypo"
     ]
   },
@@ -4243,7 +4243,7 @@
     "preferred_prefix": "ga4ghdos",
     "uri_format": "https://dataguids.org/ga4gh/dos/v1/dataobjects/$1",
     "prefix": "ga4ghdos",
-    "all_prefixes": [
+    "synonyms": [
       "ga4ghdos"
     ]
   },
@@ -4254,7 +4254,7 @@
     "preferred_prefix": "gabi",
     "uri_format": "http://www.gabipd.org/database/cgi-bin/GreenCards.pl.cgi?BioObjectId=$1&Mode=ShowBioObject",
     "prefix": "gabi",
-    "all_prefixes": [
+    "synonyms": [
       "gabi"
     ]
   },
@@ -4265,7 +4265,7 @@
     "preferred_prefix": "gateway",
     "uri_format": "https://web.www.healthdatagateway.org/dataset/$1",
     "prefix": "gateway",
-    "all_prefixes": [
+    "synonyms": [
       "gateway"
     ]
   },
@@ -4276,7 +4276,7 @@
     "preferred_prefix": "GAZ",
     "uri_format": "http://purl.obolibrary.org/obo/GAZ_$1",
     "prefix": "gaz",
-    "all_prefixes": [
+    "synonyms": [
       "gaz"
     ]
   },
@@ -4286,7 +4286,7 @@
     "preferred_prefix": "gbif",
     "uri_format": "https://www.gbif.org/species/$1",
     "prefix": "gbif",
-    "all_prefixes": [
+    "synonyms": [
       "gbif"
     ]
   },
@@ -4297,7 +4297,7 @@
     "preferred_prefix": "gc",
     "uri_format": "https://www.ncbi.nlm.nih.gov/Taxonomy/taxonomyhome.html/index.cgi?chapter=cgencodes#SG$1",
     "prefix": "gc",
-    "all_prefixes": [
+    "synonyms": [
       "gc",
       "gc_id"
     ]
@@ -4309,7 +4309,7 @@
     "preferred_prefix": "gcst",
     "uri_format": "https://www.ebi.ac.uk/gwas/studies/$1",
     "prefix": "gcst",
-    "all_prefixes": [
+    "synonyms": [
       "gcst"
     ]
   },
@@ -4320,7 +4320,7 @@
     "preferred_prefix": "gdc",
     "uri_format": "https://portal.gdc.cancer.gov/cases/$1",
     "prefix": "gdc",
-    "all_prefixes": [
+    "synonyms": [
       "gdc"
     ]
   },
@@ -4331,7 +4331,7 @@
     "preferred_prefix": "gdsc",
     "uri_format": "https://www.cancerrxgene.org/translation/Drug/$1",
     "prefix": "gdsc",
-    "all_prefixes": [
+    "synonyms": [
       "gdsc"
     ]
   },
@@ -4341,7 +4341,7 @@
     "preferred_prefix": "GECKO",
     "uri_format": "http://purl.obolibrary.org/obo/GECKO_$1",
     "prefix": "gecko",
-    "all_prefixes": [
+    "synonyms": [
       "gecko"
     ]
   },
@@ -4352,7 +4352,7 @@
     "preferred_prefix": "genatlas",
     "uri_format": "http://genatlas.medecine.univ-paris5.fr/fiche.php?symbol=$1",
     "prefix": "genatlas",
-    "all_prefixes": [
+    "synonyms": [
       "genatlas"
     ]
   },
@@ -4362,7 +4362,7 @@
     "preferred_prefix": "genbank",
     "uri_format": "https://www.ncbi.nlm.nih.gov/nucleotide/$1",
     "prefix": "genbank",
-    "all_prefixes": [
+    "synonyms": [
       "genbank"
     ]
   },
@@ -4373,7 +4373,7 @@
     "preferred_prefix": "genecards",
     "uri_format": "https://www.genecards.org/cgi-bin/carddisp.pl?gene=$1",
     "prefix": "genecards",
-    "all_prefixes": [
+    "synonyms": [
       "genecards"
     ]
   },
@@ -4384,7 +4384,7 @@
     "preferred_prefix": "genedb",
     "uri_format": "https://www.genedb.org/gene/$1",
     "prefix": "genedb",
-    "all_prefixes": [
+    "synonyms": [
       "genedb"
     ]
   },
@@ -4395,7 +4395,7 @@
     "preferred_prefix": "genefarm",
     "uri_format": "https://urgi.versailles.inra.fr/Genefarm/Gene/display_gene.htpl?GENE_ID=$1",
     "prefix": "genefarm",
-    "all_prefixes": [
+    "synonyms": [
       "genefarm"
     ]
   },
@@ -4405,7 +4405,7 @@
     "preferred_prefix": "GENEPIO",
     "uri_format": "http://purl.obolibrary.org/obo/GENEPIO_$1",
     "prefix": "genepio",
-    "all_prefixes": [
+    "synonyms": [
       "genepio"
     ]
   },
@@ -4416,7 +4416,7 @@
     "preferred_prefix": "genetree",
     "uri_format": "http://www.ensembl.org/Multi/GeneTree/Image?db=core;gt=$1",
     "prefix": "genetree",
-    "all_prefixes": [
+    "synonyms": [
       "genetree"
     ]
   },
@@ -4427,7 +4427,7 @@
     "preferred_prefix": "genewiki",
     "uri_format": "http://plugins.biogps.org/cgi-bin/wp.cgi?id=$1",
     "prefix": "genewiki",
-    "all_prefixes": [
+    "synonyms": [
       "genewiki"
     ]
   },
@@ -4438,7 +4438,7 @@
     "preferred_prefix": "GENO",
     "uri_format": "http://purl.obolibrary.org/obo/GENO_$1",
     "prefix": "geno",
-    "all_prefixes": [
+    "synonyms": [
       "geno"
     ]
   },
@@ -4449,7 +4449,7 @@
     "preferred_prefix": "genpept",
     "uri_format": "https://www.ncbi.nlm.nih.gov/protein/$1?report=genpept",
     "prefix": "genpept",
-    "all_prefixes": [
+    "synonyms": [
       "genpept"
     ]
   },
@@ -4460,7 +4460,7 @@
     "preferred_prefix": "genprop",
     "uri_format": "https://www.ebi.ac.uk/interpro/genomeproperties/#$1",
     "prefix": "genprop",
-    "all_prefixes": [
+    "synonyms": [
       "genprop"
     ]
   },
@@ -4471,7 +4471,7 @@
     "preferred_prefix": "geo",
     "uri_format": "https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=$1",
     "prefix": "geo",
-    "all_prefixes": [
+    "synonyms": [
       "geo"
     ]
   },
@@ -4482,7 +4482,7 @@
     "preferred_prefix": "GEOGEO",
     "uri_format": "http://purl.obolibrary.org/obo/GEO_$1",
     "prefix": "geogeo",
-    "all_prefixes": [
+    "synonyms": [
       "geogeo"
     ]
   },
@@ -4492,7 +4492,7 @@
     "preferred_prefix": "ghr",
     "uri_format": "https://medlineplus.gov/genetics/condition/$1",
     "prefix": "ghr",
-    "all_prefixes": [
+    "synonyms": [
       "ghr"
     ]
   },
@@ -4503,7 +4503,7 @@
     "preferred_prefix": "giardiadb",
     "uri_format": "https://giardiadb.org/giardiadb/app/record/gene/$1",
     "prefix": "giardiadb",
-    "all_prefixes": [
+    "synonyms": [
       "giardiadb"
     ]
   },
@@ -4514,7 +4514,7 @@
     "preferred_prefix": "github",
     "uri_format": "https://github.com/$1",
     "prefix": "github",
-    "all_prefixes": [
+    "synonyms": [
       "github"
     ]
   },
@@ -4525,7 +4525,7 @@
     "preferred_prefix": "glida.gpcr",
     "uri_format": "http://pharminfo.pharm.kyoto-u.ac.jp/services/glida/gpcr_information.php?id=$1",
     "prefix": "glida.gpcr",
-    "all_prefixes": [
+    "synonyms": [
       "glida.gpcr"
     ]
   },
@@ -4536,7 +4536,7 @@
     "preferred_prefix": "glida.ligand",
     "uri_format": "http://pharminfo.pharm.kyoto-u.ac.jp/services/glida/ligand_information.php?id=$1",
     "prefix": "glida.ligand",
-    "all_prefixes": [
+    "synonyms": [
       "glida.ligand"
     ]
   },
@@ -4547,7 +4547,7 @@
     "preferred_prefix": "glycoepitope",
     "uri_format": "https://www.glycoepitope.jp/epitopes/$1",
     "prefix": "glycoepitope",
-    "all_prefixes": [
+    "synonyms": [
       "glycoepitope"
     ]
   },
@@ -4558,7 +4558,7 @@
     "preferred_prefix": "glycomedb",
     "uri_format": "https://glytoucan.org/Structures/Glycans/$1",
     "prefix": "glycomedb",
-    "all_prefixes": [
+    "synonyms": [
       "glycomedb"
     ]
   },
@@ -4569,7 +4569,7 @@
     "preferred_prefix": "glyconavi",
     "uri_format": "https://glyconavi.org/hub/?id=$1",
     "prefix": "glyconavi",
-    "all_prefixes": [
+    "synonyms": [
       "glyconavi"
     ]
   },
@@ -4580,7 +4580,7 @@
     "preferred_prefix": "glycopost",
     "uri_format": "https://glycopost.glycosmos.org/entry/$1",
     "prefix": "glycopost",
-    "all_prefixes": [
+    "synonyms": [
       "glycopost"
     ]
   },
@@ -4590,7 +4590,7 @@
     "preferred_prefix": "glygen",
     "uri_format": "https://glygen.org/glycan/$1",
     "prefix": "glygen",
-    "all_prefixes": [
+    "synonyms": [
       "glygen"
     ]
   },
@@ -4601,7 +4601,7 @@
     "preferred_prefix": "glytoucan",
     "uri_format": "https://glytoucan.org/Structures/Glycans/$1",
     "prefix": "glytoucan",
-    "all_prefixes": [
+    "synonyms": [
       "glytoucan"
     ]
   },
@@ -4612,7 +4612,7 @@
     "preferred_prefix": "gmd",
     "uri_format": "http://gmd.mpimp-golm.mpg.de/Metabolites/$1.aspx",
     "prefix": "gmd",
-    "all_prefixes": [
+    "synonyms": [
       "gmd"
     ]
   },
@@ -4623,7 +4623,7 @@
     "preferred_prefix": "gmd.analyte",
     "uri_format": "http://gmd.mpimp-golm.mpg.de/Analytes/$1",
     "prefix": "gmd.analyte",
-    "all_prefixes": [
+    "synonyms": [
       "gmd.analyte"
     ]
   },
@@ -4634,7 +4634,7 @@
     "preferred_prefix": "gmd.gcms",
     "uri_format": "http://gmd.mpimp-golm.mpg.de/Spectrums/$1",
     "prefix": "gmd.gcms",
-    "all_prefixes": [
+    "synonyms": [
       "gmd.gcms"
     ]
   },
@@ -4645,7 +4645,7 @@
     "preferred_prefix": "gmd.profile",
     "uri_format": "http://gmd.mpimp-golm.mpg.de/profile/default.aspx?XemlId=$1",
     "prefix": "gmd.profile",
-    "all_prefixes": [
+    "synonyms": [
       "gmd.profile"
     ]
   },
@@ -4656,7 +4656,7 @@
     "preferred_prefix": "gmd.ref",
     "uri_format": "http://gmd.mpimp-golm.mpg.de/ReferenceSubstances/$1",
     "prefix": "gmd.ref",
-    "all_prefixes": [
+    "synonyms": [
       "gmd.ref"
     ]
   },
@@ -4667,7 +4667,7 @@
     "preferred_prefix": "GNO",
     "uri_format": "http://purl.obolibrary.org/obo/GNO_$1",
     "prefix": "gno",
-    "all_prefixes": [
+    "synonyms": [
       "gno"
     ]
   },
@@ -4678,7 +4678,7 @@
     "preferred_prefix": "gnpis",
     "uri_format": "https://urgi.versailles.inra.fr/gnpis/#result/term=$1",
     "prefix": "gnpis",
-    "all_prefixes": [
+    "synonyms": [
       "gnpis"
     ]
   },
@@ -4689,7 +4689,7 @@
     "preferred_prefix": "GO",
     "uri_format": "http://amigo.geneontology.org/amigo/term/GO:$1",
     "prefix": "go",
-    "all_prefixes": [
+    "synonyms": [
       "go",
       "gobp",
       "gobpid",
@@ -4705,7 +4705,7 @@
     "preferred_prefix": "go.model",
     "uri_format": "noctua.geneontology.org/editor/graph/gomodel:$1",
     "prefix": "go.model",
-    "all_prefixes": [
+    "synonyms": [
       "go.model"
     ]
   },
@@ -4716,7 +4716,7 @@
     "preferred_prefix": "go.ref",
     "uri_format": "https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-$1.md",
     "prefix": "go.ref",
-    "all_prefixes": [
+    "synonyms": [
       "go.ref"
     ]
   },
@@ -4727,7 +4727,7 @@
     "preferred_prefix": "goa",
     "uri_format": "https://www.ebi.ac.uk/QuickGO/GProtein?ac=$1",
     "prefix": "goa",
-    "all_prefixes": [
+    "synonyms": [
       "goa"
     ]
   },
@@ -4738,7 +4738,7 @@
     "preferred_prefix": "gold",
     "uri_format": "https://gold.jgi.doe.gov/resolver?id=$1",
     "prefix": "gold",
-    "all_prefixes": [
+    "synonyms": [
       "gold"
     ]
   },
@@ -4749,7 +4749,7 @@
     "preferred_prefix": "gold.genome",
     "uri_format": "http://www.genomesonline.org/cgi-bin/GOLD/GOLDCards.cgi?goldstamp=$1",
     "prefix": "gold.genome",
-    "all_prefixes": [
+    "synonyms": [
       "gold.genome"
     ]
   },
@@ -4760,7 +4760,7 @@
     "preferred_prefix": "gold.meta",
     "uri_format": "http://genomesonline.org/cgi-bin/GOLD/bin/GOLDCards.cgi?goldstamp=$1",
     "prefix": "gold.meta",
-    "all_prefixes": [
+    "synonyms": [
       "gold.meta"
     ]
   },
@@ -4771,7 +4771,7 @@
     "preferred_prefix": "google.patent",
     "uri_format": "https://www.google.com/patents/$1",
     "prefix": "google.patent",
-    "all_prefixes": [
+    "synonyms": [
       "google.patent",
       "patent"
     ]
@@ -4783,7 +4783,7 @@
     "preferred_prefix": "gpcrdb",
     "uri_format": "https://gpcrdb.org/protein/$1",
     "prefix": "gpcrdb",
-    "all_prefixes": [
+    "synonyms": [
       "gpcrdb"
     ]
   },
@@ -4794,7 +4794,7 @@
     "preferred_prefix": "gpmdb",
     "uri_format": "http://gpmdb.thegpm.org/~/dblist_gpmnum/gpmnum=$1",
     "prefix": "gpmdb",
-    "all_prefixes": [
+    "synonyms": [
       "gpmdb"
     ]
   },
@@ -4805,7 +4805,7 @@
     "preferred_prefix": "gramene.gene",
     "uri_format": "http://www.gramene.org/db/genes/search_gene?acc=$1",
     "prefix": "gramene.gene",
-    "all_prefixes": [
+    "synonyms": [
       "gr_gene",
       "gramene.gene"
     ]
@@ -4817,7 +4817,7 @@
     "preferred_prefix": "gramene.growthstage",
     "uri_format": "http://www.gramene.org/db/ontology/search?id=GRO:$1",
     "prefix": "gramene.growthstage",
-    "all_prefixes": [
+    "synonyms": [
       "gramene.growthstage"
     ]
   },
@@ -4828,7 +4828,7 @@
     "preferred_prefix": "gramene.protein",
     "uri_format": "http://www.gramene.org/db/protein/protein_search?protein_id=$1",
     "prefix": "gramene.protein",
-    "all_prefixes": [
+    "synonyms": [
       "gr_protein",
       "gramene.protein"
     ]
@@ -4840,7 +4840,7 @@
     "preferred_prefix": "gramene.qtl",
     "uri_format": "http://www.gramene.org/db/qtl/qtl_display?qtl_accession_id=$1",
     "prefix": "gramene.qtl",
-    "all_prefixes": [
+    "synonyms": [
       "gr_qtl",
       "gramene.qtl"
     ]
@@ -4852,7 +4852,7 @@
     "preferred_prefix": "gramene.taxonomy",
     "uri_format": "http://www.gramene.org/db/ontology/search?id=$1",
     "prefix": "gramene.taxonomy",
-    "all_prefixes": [
+    "synonyms": [
       "gramene.taxonomy"
     ]
   },
@@ -4863,7 +4863,7 @@
     "preferred_prefix": "grassbase",
     "uri_format": "https://www.kew.org/data/grasses-db/www/$1",
     "prefix": "grassbase",
-    "all_prefixes": [
+    "synonyms": [
       "grassbase"
     ]
   },
@@ -4874,7 +4874,7 @@
     "preferred_prefix": "greengenes",
     "uri_format": "http://greengenes.lbl.gov/cgi-bin/show_one_record_v2.pl?prokMSA_id=$1",
     "prefix": "greengenes",
-    "all_prefixes": [
+    "synonyms": [
       "greengenes"
     ]
   },
@@ -4885,7 +4885,7 @@
     "preferred_prefix": "grid",
     "uri_format": "https://www.grid.ac/institutes/$1",
     "prefix": "grid",
-    "all_prefixes": [
+    "synonyms": [
       "grid"
     ]
   },
@@ -4896,7 +4896,7 @@
     "preferred_prefix": "grin.taxonomy",
     "uri_format": "http://www.ars-grin.gov/cgi-bin/npgs/html/taxon.pl?$1",
     "prefix": "grin.taxonomy",
-    "all_prefixes": [
+    "synonyms": [
       "grin.taxonomy"
     ]
   },
@@ -4907,7 +4907,7 @@
     "preferred_prefix": "grsdb",
     "uri_format": "http://bioinformatics.ramapo.edu/GRSDB2/geneview.php?geneID=$1",
     "prefix": "grsdb",
-    "all_prefixes": [
+    "synonyms": [
       "grsdb"
     ]
   },
@@ -4917,7 +4917,7 @@
     "preferred_prefix": "gsfa",
     "uri_format": "http://www.fao.org/gsfaonline/additives/details.html?id=$1",
     "prefix": "gsfa",
-    "all_prefixes": [
+    "synonyms": [
       "gsfa"
     ]
   },
@@ -4928,7 +4928,7 @@
     "preferred_prefix": "GSSO",
     "uri_format": "http://purl.obolibrary.org/obo/GSSO_$1",
     "prefix": "gsso",
-    "all_prefixes": [
+    "synonyms": [
       "gsso"
     ]
   },
@@ -4939,7 +4939,7 @@
     "preferred_prefix": "gtex",
     "uri_format": "https://www.gtexportal.org/home/gene/$1",
     "prefix": "gtex",
-    "all_prefixes": [
+    "synonyms": [
       "gtex"
     ]
   },
@@ -4950,7 +4950,7 @@
     "preferred_prefix": "gudmap",
     "uri_format": "https://gudmap.org/id/$1",
     "prefix": "gudmap",
-    "all_prefixes": [
+    "synonyms": [
       "gudmap"
     ]
   },
@@ -4961,7 +4961,7 @@
     "preferred_prefix": "gwascentral.marker",
     "uri_format": "https://www.gwascentral.org/marker/$1",
     "prefix": "gwascentral.marker",
-    "all_prefixes": [
+    "synonyms": [
       "gwascentral.marker"
     ]
   },
@@ -4972,7 +4972,7 @@
     "preferred_prefix": "gwascentral.phenotype",
     "uri_format": "https://www.gwascentral.org/phenotype/$1",
     "prefix": "gwascentral.phenotype",
-    "all_prefixes": [
+    "synonyms": [
       "gwascentral.phenotype"
     ]
   },
@@ -4983,7 +4983,7 @@
     "preferred_prefix": "gwascentral.study",
     "uri_format": "https://www.gwascentral.org/study/$1",
     "prefix": "gwascentral.study",
-    "all_prefixes": [
+    "synonyms": [
       "gwascentral.study"
     ]
   },
@@ -4994,7 +4994,7 @@
     "preferred_prefix": "gxa.expt",
     "uri_format": "https://www.ebi.ac.uk/gxa/experiments/$1",
     "prefix": "gxa.expt",
-    "all_prefixes": [
+    "synonyms": [
       "gxa.expt"
     ]
   },
@@ -5005,7 +5005,7 @@
     "preferred_prefix": "gxa.gene",
     "uri_format": "https://www.ebi.ac.uk/gxa/genes/$1",
     "prefix": "gxa.gene",
-    "all_prefixes": [
+    "synonyms": [
       "gxa.gene"
     ]
   },
@@ -5015,7 +5015,7 @@
     "preferred_prefix": "HABRONATTUS",
     "uri_format": "http://purl.obolibrary.org/obo/HABRONATTUS_$1",
     "prefix": "habronattus",
-    "all_prefixes": [
+    "synonyms": [
       "habronattus"
     ]
   },
@@ -5026,7 +5026,7 @@
     "preferred_prefix": "hamap",
     "uri_format": "https://hamap.expasy.org/unirule/$1",
     "prefix": "hamap",
-    "all_prefixes": [
+    "synonyms": [
       "hamap"
     ]
   },
@@ -5036,7 +5036,7 @@
     "preferred_prefix": "HANCESTRO",
     "uri_format": "http://purl.obolibrary.org/obo/HANCESTRO_$1",
     "prefix": "hancestro",
-    "all_prefixes": [
+    "synonyms": [
       "hancestro"
     ]
   },
@@ -5047,7 +5047,7 @@
     "preferred_prefix": "HAO",
     "uri_format": "http://purl.obolibrary.org/obo/HAO_$1",
     "prefix": "hao",
-    "all_prefixes": [
+    "synonyms": [
       "hao"
     ]
   },
@@ -5058,7 +5058,7 @@
     "preferred_prefix": "hcvdb",
     "uri_format": "https://euhcvdb.ibcp.fr/euHCVdb/do/displayHCVEntry?primaryAC=$1",
     "prefix": "hcvdb",
-    "all_prefixes": [
+    "synonyms": [
       "hcvdb"
     ]
   },
@@ -5069,7 +5069,7 @@
     "preferred_prefix": "hdr",
     "uri_format": "http://research.nhgri.nih.gov/apps/homeodomain/web/index.cgi?mode=view&amp;view=proteins&amp;id=$1",
     "prefix": "hdr",
-    "all_prefixes": [
+    "synonyms": [
       "hdr"
     ]
   },
@@ -5080,7 +5080,7 @@
     "preferred_prefix": "hgmd",
     "uri_format": "http://www.hgmd.cf.ac.uk/ac/gene.php?gene=$1",
     "prefix": "hgmd",
-    "all_prefixes": [
+    "synonyms": [
       "hgmd"
     ]
   },
@@ -5091,7 +5091,7 @@
     "preferred_prefix": "hgnc",
     "uri_format": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/$1",
     "prefix": "hgnc",
-    "all_prefixes": [
+    "synonyms": [
       "hgnc"
     ]
   },
@@ -5103,7 +5103,7 @@
     "preferred_prefix": "hgnc.genefamily",
     "uri_format": "https://www.genenames.org/cgi-bin/genefamilies/set/$1",
     "prefix": "hgnc.genefamily",
-    "all_prefixes": [
+    "synonyms": [
       "gfam",
       "hgnc.family",
       "hgnc.genefamily",
@@ -5117,7 +5117,7 @@
     "preferred_prefix": "hgnc.genegroup",
     "uri_format": "https://www.genenames.org/cgi-bin/genefamilies/set/$1",
     "prefix": "hgnc.genegroup",
-    "all_prefixes": [
+    "synonyms": [
       "hgnc.genegroup"
     ]
   },
@@ -5128,7 +5128,7 @@
     "preferred_prefix": "hgnc.symbol",
     "uri_format": "https://www.genenames.org/cgi-bin/gene_symbol_report?match=$1",
     "prefix": "hgnc.symbol",
-    "all_prefixes": [
+    "synonyms": [
       "hgnc.symbol"
     ]
   },
@@ -5139,7 +5139,7 @@
     "preferred_prefix": "hinv.locus",
     "uri_format": "http://h-invitational.jp/hinv/spsoup/locus_view?hix_id=$1",
     "prefix": "hinv.locus",
-    "all_prefixes": [
+    "synonyms": [
       "hinv.locus"
     ]
   },
@@ -5150,7 +5150,7 @@
     "preferred_prefix": "hinv.protein",
     "uri_format": "http://h-invitational.jp/hinv/protein/protein_view.cgi?hip_id=$1",
     "prefix": "hinv.protein",
-    "all_prefixes": [
+    "synonyms": [
       "hinv.protein"
     ]
   },
@@ -5161,7 +5161,7 @@
     "preferred_prefix": "hinv.transcript",
     "uri_format": "http://h-invitational.jp/hinv/spsoup/transcript_view?hit_id=$1",
     "prefix": "hinv.transcript",
-    "all_prefixes": [
+    "synonyms": [
       "hinv.transcript"
     ]
   },
@@ -5172,7 +5172,7 @@
     "preferred_prefix": "hmdb",
     "uri_format": "http://www.hmdb.ca/metabolites/$1",
     "prefix": "hmdb",
-    "all_prefixes": [
+    "synonyms": [
       "hmdb"
     ]
   },
@@ -5182,7 +5182,7 @@
     "preferred_prefix": "hms.lincs.compound",
     "uri_format": "https://lincs.hms.harvard.edu/db/sm/$1",
     "prefix": "hms.lincs.compound",
-    "all_prefixes": [
+    "synonyms": [
       "hms-lincs",
       "hms.lincs.compound",
       "hmsl_id"
@@ -5195,7 +5195,7 @@
     "preferred_prefix": "hogenom",
     "uri_format": "http://pbil.univ-lyon1.fr/cgi-bin/view-tree.pl?db=HOGENOM5&query=$1",
     "prefix": "hogenom",
-    "all_prefixes": [
+    "synonyms": [
       "hogenom"
     ]
   },
@@ -5205,7 +5205,7 @@
     "preferred_prefix": "HOM",
     "uri_format": "http://purl.obolibrary.org/obo/HOM_$1",
     "prefix": "hom",
-    "all_prefixes": [
+    "synonyms": [
       "hom"
     ]
   },
@@ -5216,7 +5216,7 @@
     "preferred_prefix": "homd.seq",
     "uri_format": "http://www.homd.org/modules.php?op=modload&name=GenomeList&file=index&link=detailinfo&seqid=$1",
     "prefix": "homd.seq",
-    "all_prefixes": [
+    "synonyms": [
       "homd.seq"
     ]
   },
@@ -5227,7 +5227,7 @@
     "preferred_prefix": "homd.taxon",
     "uri_format": "www.homd.org/modules.php?op=modload&name=HOMD&view=dynamic&oraltaxonid=$1",
     "prefix": "homd.taxon",
-    "all_prefixes": [
+    "synonyms": [
       "homd.taxon"
     ]
   },
@@ -5238,7 +5238,7 @@
     "preferred_prefix": "homologene",
     "uri_format": "https://www.ncbi.nlm.nih.gov/homologene/$1",
     "prefix": "homologene",
-    "all_prefixes": [
+    "synonyms": [
       "homologene"
     ]
   },
@@ -5249,7 +5249,7 @@
     "preferred_prefix": "hovergen",
     "uri_format": "http://pbil.univ-lyon1.fr/cgi-bin/view-tree.pl?query=$1&db=HOVERGEN",
     "prefix": "hovergen",
-    "all_prefixes": [
+    "synonyms": [
       "hovergen"
     ]
   },
@@ -5260,7 +5260,7 @@
     "preferred_prefix": "HP",
     "uri_format": "https://hpo.jax.org/app/browse/term/HP:$1",
     "prefix": "hp",
-    "all_prefixes": [
+    "synonyms": [
       "hp"
     ]
   },
@@ -5271,7 +5271,7 @@
     "preferred_prefix": "hpa",
     "uri_format": "http://www.proteinatlas.org/$1",
     "prefix": "hpa",
-    "all_prefixes": [
+    "synonyms": [
       "hpa"
     ]
   },
@@ -5282,7 +5282,7 @@
     "preferred_prefix": "hpm.peptide",
     "uri_format": "http://www.humanproteomemap.org/spectrum.php?pep_id=$1",
     "prefix": "hpm.peptide",
-    "all_prefixes": [
+    "synonyms": [
       "hpm.peptide"
     ]
   },
@@ -5293,7 +5293,7 @@
     "preferred_prefix": "hpm.protein",
     "uri_format": "http://www.humanproteomemap.org/protein.php?hpm_id=$1",
     "prefix": "hpm.protein",
-    "all_prefixes": [
+    "synonyms": [
       "hpm.protein"
     ]
   },
@@ -5304,7 +5304,7 @@
     "preferred_prefix": "hprd",
     "uri_format": "http://www.hprd.org/protein/$1",
     "prefix": "hprd",
-    "all_prefixes": [
+    "synonyms": [
       "hprd"
     ]
   },
@@ -5315,7 +5315,7 @@
     "preferred_prefix": "hpscreg",
     "uri_format": "https://hpscreg.eu/cell-line/$1",
     "prefix": "hpscreg",
-    "all_prefixes": [
+    "synonyms": [
       "hpscreg"
     ]
   },
@@ -5326,7 +5326,7 @@
     "preferred_prefix": "HsapDv",
     "uri_format": "http://purl.obolibrary.org/obo/HSAPDV_$1",
     "prefix": "hsapdv",
-    "all_prefixes": [
+    "synonyms": [
       "hsapdv"
     ]
   },
@@ -5336,7 +5336,7 @@
     "preferred_prefix": "hsdb",
     "uri_format": "https://pubchem.ncbi.nlm.nih.gov/source/hsdb/$1",
     "prefix": "hsdb",
-    "all_prefixes": [
+    "synonyms": [
       "hsdb"
     ]
   },
@@ -5346,7 +5346,7 @@
     "preferred_prefix": "HSO",
     "uri_format": "http://purl.obolibrary.org/obo/HSO_$1",
     "prefix": "hso",
-    "all_prefixes": [
+    "synonyms": [
       "hso"
     ]
   },
@@ -5357,7 +5357,7 @@
     "preferred_prefix": "hssp",
     "uri_format": "ftp://ftp.embl-heidelberg.de/pub/databases/protein_extras/hssp/$1.hssp.bz2",
     "prefix": "hssp",
-    "all_prefixes": [
+    "synonyms": [
       "hssp"
     ]
   },
@@ -5367,7 +5367,7 @@
     "preferred_prefix": "HTN",
     "uri_format": "http://purl.obolibrary.org/obo/HTN_$1",
     "prefix": "htn",
-    "all_prefixes": [
+    "synonyms": [
       "htn"
     ]
   },
@@ -5378,7 +5378,7 @@
     "preferred_prefix": "huge",
     "uri_format": "https://www.kazusa.or.jp/huge/gfpage/$1",
     "prefix": "huge",
-    "all_prefixes": [
+    "synonyms": [
       "huge"
     ]
   },
@@ -5389,7 +5389,7 @@
     "preferred_prefix": "IAO",
     "uri_format": "http://purl.obolibrary.org/obo/IAO_$1",
     "prefix": "iao",
-    "all_prefixes": [
+    "synonyms": [
       "iao"
     ]
   },
@@ -5400,7 +5400,7 @@
     "preferred_prefix": "icd10",
     "uri_format": "http://apps.who.int/classifications/icd10/browse/2010/en#/$1",
     "prefix": "icd10",
-    "all_prefixes": [
+    "synonyms": [
       "icd",
       "icd-10",
       "icd10",
@@ -5414,7 +5414,7 @@
     "preferred_prefix": "icdc",
     "uri_format": "https://caninecommons.cancer.gov/#/study/$1",
     "prefix": "icdc",
-    "all_prefixes": [
+    "synonyms": [
       "icdc"
     ]
   },
@@ -5425,7 +5425,7 @@
     "preferred_prefix": "iceberg.element",
     "uri_format": "http://db-mml.sjtu.edu.cn/ICEberg/feature_page.php?ice_id=$1",
     "prefix": "iceberg.element",
-    "all_prefixes": [
+    "synonyms": [
       "iceberg.element"
     ]
   },
@@ -5436,7 +5436,7 @@
     "preferred_prefix": "iceberg.family",
     "uri_format": "http://db-mml.sjtu.edu.cn/ICEberg/browse_result.php?type=fam&fam_id=$1",
     "prefix": "iceberg.family",
-    "all_prefixes": [
+    "synonyms": [
       "iceberg.family"
     ]
   },
@@ -5446,7 +5446,7 @@
     "preferred_prefix": "ICEO",
     "uri_format": "http://purl.obolibrary.org/obo/ICEO_$1",
     "prefix": "iceo",
-    "all_prefixes": [
+    "synonyms": [
       "iceo"
     ]
   },
@@ -5456,7 +5456,7 @@
     "preferred_prefix": "ICO",
     "uri_format": "http://purl.obolibrary.org/obo/ICO_$1",
     "prefix": "ico",
-    "all_prefixes": [
+    "synonyms": [
       "ico"
     ]
   },
@@ -5467,7 +5467,7 @@
     "preferred_prefix": "ideal",
     "uri_format": "http://idp1.force.cs.is.nagoya-u.ac.jp/IDEAL/ideal.php?id=$1",
     "prefix": "ideal",
-    "all_prefixes": [
+    "synonyms": [
       "ideal"
     ]
   },
@@ -5478,7 +5478,7 @@
     "preferred_prefix": "identifiers.namespace",
     "uri_format": "https://identifiers.org/identifiers.namespace:$1",
     "prefix": "identifiers.namespace",
-    "all_prefixes": [
+    "synonyms": [
       "identifiers.namespace"
     ]
   },
@@ -5489,7 +5489,7 @@
     "preferred_prefix": "IDO",
     "uri_format": "https://www.ebi.ac.uk/ols/ontologies/ido/terms?obo_id=IDO:$1",
     "prefix": "ido",
-    "all_prefixes": [
+    "synonyms": [
       "ido"
     ]
   },
@@ -5500,7 +5500,7 @@
     "preferred_prefix": "IDOMAL",
     "uri_format": "http://purl.obolibrary.org/obo/IDOMAL_$1",
     "prefix": "idomal",
-    "all_prefixes": [
+    "synonyms": [
       "idomal"
     ]
   },
@@ -5511,7 +5511,7 @@
     "preferred_prefix": "idoo",
     "uri_format": "https://identifiers.org/idoo:$1",
     "prefix": "idoo",
-    "all_prefixes": [
+    "synonyms": [
       "idoo"
     ]
   },
@@ -5522,7 +5522,7 @@
     "preferred_prefix": "idot",
     "uri_format": "https://biomodels.net/vocab/idot.rdf#$1",
     "prefix": "idot",
-    "all_prefixes": [
+    "synonyms": [
       "idot"
     ]
   },
@@ -5533,7 +5533,7 @@
     "preferred_prefix": "idr",
     "uri_format": "https://idr.openmicroscopy.org/search/?query=Name:idr$1",
     "prefix": "idr",
-    "all_prefixes": [
+    "synonyms": [
       "idr"
     ]
   },
@@ -5544,7 +5544,7 @@
     "preferred_prefix": "iedb",
     "uri_format": "https://www.iedb.org/reference/$1",
     "prefix": "iedb",
-    "all_prefixes": [
+    "synonyms": [
       "iedb"
     ]
   },
@@ -5554,7 +5554,7 @@
     "preferred_prefix": "IEV",
     "uri_format": "http://purl.obolibrary.org/obo/IEV_$1",
     "prefix": "iev",
-    "all_prefixes": [
+    "synonyms": [
       "iev"
     ]
   },
@@ -5565,7 +5565,7 @@
     "preferred_prefix": "igsn",
     "uri_format": "http://igsn.org/$1",
     "prefix": "igsn",
-    "all_prefixes": [
+    "synonyms": [
       "igsn"
     ]
   },
@@ -5576,7 +5576,7 @@
     "preferred_prefix": "imex",
     "uri_format": "https://www.ebi.ac.uk/intact/imex/main.xhtml?query=$1",
     "prefix": "imex",
-    "all_prefixes": [
+    "synonyms": [
       "imex"
     ]
   },
@@ -5587,7 +5587,7 @@
     "preferred_prefix": "img.gene",
     "uri_format": "http://img.jgi.doe.gov/cgi-bin/w/main.cgi?section=GeneDetail&gene_oid=$1",
     "prefix": "img.gene",
-    "all_prefixes": [
+    "synonyms": [
       "img.gene"
     ]
   },
@@ -5598,7 +5598,7 @@
     "preferred_prefix": "img.taxon",
     "uri_format": "http://img.jgi.doe.gov/cgi-bin/w/main.cgi?section=TaxonDetail&taxon_oid=$1",
     "prefix": "img.taxon",
-    "all_prefixes": [
+    "synonyms": [
       "img.taxon"
     ]
   },
@@ -5609,7 +5609,7 @@
     "preferred_prefix": "imgt.hla",
     "uri_format": "https://www.ebi.ac.uk/cgi-bin/imgt/hla/get_allele.cgi?$1",
     "prefix": "imgt.hla",
-    "all_prefixes": [
+    "synonyms": [
       "imgt.hla"
     ]
   },
@@ -5620,7 +5620,7 @@
     "preferred_prefix": "imgt.ligm",
     "uri_format": "http://www.imgt.org/ligmdb/view?id=$1",
     "prefix": "imgt.ligm",
-    "all_prefixes": [
+    "synonyms": [
       "imgt.ligm"
     ]
   },
@@ -5630,7 +5630,7 @@
     "preferred_prefix": "IMR",
     "uri_format": "http://purl.obolibrary.org/obo/IMR_$1",
     "prefix": "imr",
-    "all_prefixes": [
+    "synonyms": [
       "imr"
     ]
   },
@@ -5641,7 +5641,7 @@
     "preferred_prefix": "inchi",
     "uri_format": "http://www.chemspider.com/$1",
     "prefix": "inchi",
-    "all_prefixes": [
+    "synonyms": [
       "inchi"
     ]
   },
@@ -5652,7 +5652,7 @@
     "preferred_prefix": "inchikey",
     "uri_format": "http://www.chemspider.com/inchikey=$1",
     "prefix": "inchikey",
-    "all_prefixes": [
+    "synonyms": [
       "inchikey"
     ]
   },
@@ -5662,7 +5662,7 @@
     "preferred_prefix": "inn",
     "uri_format": "https://mednet-communities.net/inn/db/ViewINN.aspx?i=$1",
     "prefix": "inn",
-    "all_prefixes": [
+    "synonyms": [
       "inn",
       "inn_id"
     ]
@@ -5673,7 +5673,7 @@
     "preferred_prefix": "INO",
     "uri_format": "http://purl.obolibrary.org/obo/INO_$1",
     "prefix": "ino",
-    "all_prefixes": [
+    "synonyms": [
       "ino"
     ]
   },
@@ -5684,7 +5684,7 @@
     "preferred_prefix": "insdc",
     "uri_format": "https://www.ncbi.nlm.nih.gov/nuccore/$1",
     "prefix": "insdc",
-    "all_prefixes": [
+    "synonyms": [
       "insdc"
     ]
   },
@@ -5695,7 +5695,7 @@
     "preferred_prefix": "insdc.cds",
     "uri_format": "http://getentry.ddbj.nig.ac.jp/getentry/dad/$1",
     "prefix": "insdc.cds",
-    "all_prefixes": [
+    "synonyms": [
       "insdc.cds"
     ]
   },
@@ -5706,7 +5706,7 @@
     "preferred_prefix": "insdc.gca",
     "uri_format": "https://www.ebi.ac.uk/ena/data/view/$1",
     "prefix": "insdc.gca",
-    "all_prefixes": [
+    "synonyms": [
       "insdc.gca"
     ]
   },
@@ -5717,7 +5717,7 @@
     "preferred_prefix": "insdc.run",
     "uri_format": "https://www.ebi.ac.uk/ena/browser/view/$1",
     "prefix": "insdc.run",
-    "all_prefixes": [
+    "synonyms": [
       "insdc.run"
     ]
   },
@@ -5728,7 +5728,7 @@
     "preferred_prefix": "insdc.sra",
     "uri_format": "https://www.ncbi.nlm.nih.gov/sra/$1",
     "prefix": "insdc.sra",
-    "all_prefixes": [
+    "synonyms": [
       "insdc.sra"
     ]
   },
@@ -5739,7 +5739,7 @@
     "preferred_prefix": "intact",
     "uri_format": "https://www.ebi.ac.uk/intact/interaction/$1",
     "prefix": "intact",
-    "all_prefixes": [
+    "synonyms": [
       "intact"
     ]
   },
@@ -5750,7 +5750,7 @@
     "preferred_prefix": "intact.molecule",
     "uri_format": "https://www.ebi.ac.uk/intact/molecule/$1",
     "prefix": "intact.molecule",
-    "all_prefixes": [
+    "synonyms": [
       "intact.molecule"
     ]
   },
@@ -5761,7 +5761,7 @@
     "preferred_prefix": "interlex",
     "uri_format": "https://scicrunch.org/scicrunch/interlex/view/ilx_$1",
     "prefix": "interlex",
-    "all_prefixes": [
+    "synonyms": [
       "ilx",
       "interlex"
     ]
@@ -5773,7 +5773,7 @@
     "preferred_prefix": "interpro",
     "uri_format": "https://www.ebi.ac.uk/interpro/entry/$1",
     "prefix": "interpro",
-    "all_prefixes": [
+    "synonyms": [
       "interpro",
       "ip",
       "ipr"
@@ -5786,7 +5786,7 @@
     "preferred_prefix": "ird.segment",
     "uri_format": "http://www.fludb.org/brc/fluSegmentDetails.do?ncbiGenomicAccession=$1",
     "prefix": "ird.segment",
-    "all_prefixes": [
+    "synonyms": [
       "ird.segment"
     ]
   },
@@ -5797,7 +5797,7 @@
     "preferred_prefix": "irefweb",
     "uri_format": "http://wodaklab.org/iRefWeb/interaction/show/$1",
     "prefix": "irefweb",
-    "all_prefixes": [
+    "synonyms": [
       "irefweb"
     ]
   },
@@ -5808,7 +5808,7 @@
     "preferred_prefix": "iro",
     "uri_format": "https://legacy.vectorbase.org/ontology-browser?cv=MIRO&t=IRO:$1",
     "prefix": "iro",
-    "all_prefixes": [
+    "synonyms": [
       "iro"
     ]
   },
@@ -5819,7 +5819,7 @@
     "preferred_prefix": "isbn",
     "uri_format": "http://isbndb.com/search-all.html?kw=$1",
     "prefix": "isbn",
-    "all_prefixes": [
+    "synonyms": [
       "isbn",
       "isbn-10",
       "isbn-13"
@@ -5832,7 +5832,7 @@
     "preferred_prefix": "isfinder",
     "uri_format": "https://www-is.biotoul.fr/scripts/ficheIS.php?name=$1",
     "prefix": "isfinder",
-    "all_prefixes": [
+    "synonyms": [
       "isfinder"
     ]
   },
@@ -5843,7 +5843,7 @@
     "preferred_prefix": "isni",
     "uri_format": "http://www.isni.org/isni/$1",
     "prefix": "isni",
-    "all_prefixes": [
+    "synonyms": [
       "isni"
     ]
   },
@@ -5854,7 +5854,7 @@
     "preferred_prefix": "issn",
     "uri_format": "https://portal.issn.org/resource/ISSN/$1",
     "prefix": "issn",
-    "all_prefixes": [
+    "synonyms": [
       "issn"
     ]
   },
@@ -5865,7 +5865,7 @@
     "preferred_prefix": "itis",
     "uri_format": "https://www.itis.gov/servlet/SingleRpt/SingleRpt?search_topic=TSN&search_value=$1",
     "prefix": "itis",
-    "all_prefixes": [
+    "synonyms": [
       "itis"
     ]
   },
@@ -5876,7 +5876,7 @@
     "preferred_prefix": "ito",
     "uri_format": "https://bioportal.bioontology.org/ontologies/ITO/?p=classes&conceptid=https%3A%2F%2Fai-strategies.org%2Fontology%2F$1",
     "prefix": "ito",
-    "all_prefixes": [
+    "synonyms": [
       "ito"
     ]
   },
@@ -5887,7 +5887,7 @@
     "preferred_prefix": "iuphar.family",
     "uri_format": "http://www.guidetopharmacology.org/GRAC/FamilyDisplayForward?familyId=$1",
     "prefix": "iuphar.family",
-    "all_prefixes": [
+    "synonyms": [
       "iuphar.family",
       "iupharfam"
     ]
@@ -5899,7 +5899,7 @@
     "preferred_prefix": "iuphar.ligand",
     "uri_format": "http://www.guidetopharmacology.org/GRAC/LigandDisplayForward?ligandId=$1",
     "prefix": "iuphar.ligand",
-    "all_prefixes": [
+    "synonyms": [
       "iuphar.ligand",
       "iuphar_ligand",
       "iuphar_ligand_id"
@@ -5912,7 +5912,7 @@
     "preferred_prefix": "iuphar.receptor",
     "uri_format": "http://www.guidetopharmacology.org/GRAC/ObjectDisplayForward?objectId=$1",
     "prefix": "iuphar.receptor",
-    "all_prefixes": [
+    "synonyms": [
       "iuphar.receptor",
       "iuphar_gpcr",
       "iupharobj"
@@ -5924,7 +5924,7 @@
     "preferred_prefix": "jax",
     "uri_format": "https://www.jax.org/strain/$1",
     "prefix": "jax",
-    "all_prefixes": [
+    "synonyms": [
       "jax"
     ]
   },
@@ -5935,7 +5935,7 @@
     "preferred_prefix": "jaxmice",
     "uri_format": "http://jaxmice.jax.org/strain/$1.html",
     "prefix": "jaxmice",
-    "all_prefixes": [
+    "synonyms": [
       "jaxmice"
     ]
   },
@@ -5946,7 +5946,7 @@
     "preferred_prefix": "jcggdb",
     "uri_format": "http://jcggdb.jp/idb/jcggdb/$1",
     "prefix": "jcggdb",
-    "all_prefixes": [
+    "synonyms": [
       "jcggdb"
     ]
   },
@@ -5957,7 +5957,7 @@
     "preferred_prefix": "jcm",
     "uri_format": "http://www.jcm.riken.go.jp/cgi-bin/jcm/jcm_number?JCM=$1",
     "prefix": "jcm",
-    "all_prefixes": [
+    "synonyms": [
       "jcm"
     ]
   },
@@ -5968,7 +5968,7 @@
     "preferred_prefix": "jcsd",
     "uri_format": "http://jglobal.jst.go.jp/en/redirect?Nikkaji_No=$1",
     "prefix": "jcsd",
-    "all_prefixes": [
+    "synonyms": [
       "jcsd"
     ]
   },
@@ -5979,7 +5979,7 @@
     "preferred_prefix": "jstor",
     "uri_format": "http://www.jstor.org/stable/$1",
     "prefix": "jstor",
-    "all_prefixes": [
+    "synonyms": [
       "jstor"
     ]
   },
@@ -5990,7 +5990,7 @@
     "preferred_prefix": "jws",
     "uri_format": "https://jjj.bio.vu.nl/models/$1",
     "prefix": "jws",
-    "all_prefixes": [
+    "synonyms": [
       "jws"
     ]
   },
@@ -6001,7 +6001,7 @@
     "preferred_prefix": "kaggle",
     "uri_format": "https://www.kaggle.com/$1",
     "prefix": "kaggle",
-    "all_prefixes": [
+    "synonyms": [
       "kaggle"
     ]
   },
@@ -6013,7 +6013,7 @@
     "preferred_prefix": "kegg",
     "uri_format": "http://www.kegg.jp/entry/$1",
     "prefix": "kegg",
-    "all_prefixes": [
+    "synonyms": [
       "kegg"
     ]
   },
@@ -6024,7 +6024,7 @@
     "preferred_prefix": "kegg.compound",
     "uri_format": "https://www.kegg.jp/entry/$1",
     "prefix": "kegg.compound",
-    "all_prefixes": [
+    "synonyms": [
       "kegg.compound"
     ]
   },
@@ -6035,7 +6035,7 @@
     "preferred_prefix": "kegg.disease",
     "uri_format": "http://www.kegg.jp/entry/$1",
     "prefix": "kegg.disease",
-    "all_prefixes": [
+    "synonyms": [
       "kegg.disease"
     ]
   },
@@ -6046,7 +6046,7 @@
     "preferred_prefix": "kegg.drug",
     "uri_format": "https://www.kegg.jp/entry/$1",
     "prefix": "kegg.drug",
-    "all_prefixes": [
+    "synonyms": [
       "kegg.drug"
     ]
   },
@@ -6057,7 +6057,7 @@
     "preferred_prefix": "kegg.environ",
     "uri_format": "http://www.kegg.jp/entry/$1",
     "prefix": "kegg.environ",
-    "all_prefixes": [
+    "synonyms": [
       "kegg.environ"
     ]
   },
@@ -6066,7 +6066,7 @@
     "preferred_prefix": "kegg.enzyme",
     "uri_format": "http://www.genome.jp/dbget-bin/www_bget?ec:$1",
     "prefix": "kegg.enzyme",
-    "all_prefixes": [
+    "synonyms": [
       "kegg.enzyme"
     ]
   },
@@ -6077,7 +6077,7 @@
     "preferred_prefix": "kegg.genes",
     "uri_format": "http://www.kegg.jp/entry/$1",
     "prefix": "kegg.genes",
-    "all_prefixes": [
+    "synonyms": [
       "kegg.genes"
     ]
   },
@@ -6088,7 +6088,7 @@
     "preferred_prefix": "kegg.genome",
     "uri_format": "http://www.kegg.jp/entry/$1",
     "prefix": "kegg.genome",
-    "all_prefixes": [
+    "synonyms": [
       "kegg.genome",
       "kegg_genome",
       "kegg_genomes"
@@ -6101,7 +6101,7 @@
     "preferred_prefix": "kegg.glycan",
     "uri_format": "https://www.kegg.jp/entry/$1",
     "prefix": "kegg.glycan",
-    "all_prefixes": [
+    "synonyms": [
       "kegg.glycan"
     ]
   },
@@ -6111,7 +6111,7 @@
     "preferred_prefix": "kegg.ligand",
     "uri_format": "http://www.genome.jp/dbget-bin/www_bget?cpd:$1",
     "prefix": "kegg.ligand",
-    "all_prefixes": [
+    "synonyms": [
       "kegg.ligand"
     ]
   },
@@ -6122,7 +6122,7 @@
     "preferred_prefix": "kegg.metagenome",
     "uri_format": "http://www.kegg.jp/entry/$1",
     "prefix": "kegg.metagenome",
-    "all_prefixes": [
+    "synonyms": [
       "kegg.metagenome"
     ]
   },
@@ -6133,7 +6133,7 @@
     "preferred_prefix": "kegg.module",
     "uri_format": "http://www.kegg.jp/entry/$1",
     "prefix": "kegg.module",
-    "all_prefixes": [
+    "synonyms": [
       "kegg.module"
     ]
   },
@@ -6144,7 +6144,7 @@
     "preferred_prefix": "kegg.orthology",
     "uri_format": "http://www.kegg.jp/entry/$1",
     "prefix": "kegg.orthology",
-    "all_prefixes": [
+    "synonyms": [
       "kegg.orthology"
     ]
   },
@@ -6155,7 +6155,7 @@
     "preferred_prefix": "kegg.pathway",
     "uri_format": "https://www.kegg.jp/entry/$1",
     "prefix": "kegg.pathway",
-    "all_prefixes": [
+    "synonyms": [
       "kegg-path",
       "kegg.pathway",
       "kegg_pathway"
@@ -6168,7 +6168,7 @@
     "preferred_prefix": "kegg.reaction",
     "uri_format": "https://www.kegg.jp/entry/$1",
     "prefix": "kegg.reaction",
-    "all_prefixes": [
+    "synonyms": [
       "kegg.reaction",
       "kegg_reaction"
     ]
@@ -6180,7 +6180,7 @@
     "preferred_prefix": "knapsack",
     "uri_format": "http://www.knapsackfamily.com/knapsack_core/information.php?word=$1",
     "prefix": "knapsack",
-    "all_prefixes": [
+    "synonyms": [
       "knapsack"
     ]
   },
@@ -6190,7 +6190,7 @@
     "preferred_prefix": "LABO",
     "uri_format": "http://purl.obolibrary.org/obo/LABO_$1",
     "prefix": "labo",
-    "all_prefixes": [
+    "synonyms": [
       "labo"
     ]
   },
@@ -6201,7 +6201,7 @@
     "preferred_prefix": "lei",
     "uri_format": "https://www.gleif.org/lei/$1",
     "prefix": "lei",
-    "all_prefixes": [
+    "synonyms": [
       "lei"
     ]
   },
@@ -6212,7 +6212,7 @@
     "preferred_prefix": "lgai.cede",
     "uri_format": "https://s3.us-east-2.amazonaws.com/lg.cede/$1",
     "prefix": "lgai.cede",
-    "all_prefixes": [
+    "synonyms": [
       "lgai.cede"
     ]
   },
@@ -6224,7 +6224,7 @@
     "preferred_prefix": "lgic",
     "uri_format": "https://www.ebi.ac.uk/compneur-srv/LGICdb/HTML/$1.php",
     "prefix": "lgic",
-    "all_prefixes": [
+    "synonyms": [
       "lgic"
     ]
   },
@@ -6235,7 +6235,7 @@
     "preferred_prefix": "licebase",
     "uri_format": "https://licebase.org/?q=$1",
     "prefix": "licebase",
-    "all_prefixes": [
+    "synonyms": [
       "licebase"
     ]
   },
@@ -6246,7 +6246,7 @@
     "preferred_prefix": "ligandbook",
     "uri_format": "https://ligandbook.org/package/$1",
     "prefix": "ligandbook",
-    "all_prefixes": [
+    "synonyms": [
       "ligandbook"
     ]
   },
@@ -6257,7 +6257,7 @@
     "preferred_prefix": "ligandbox",
     "uri_format": "http://www.mypresto5.com/ligandbox/cgi-bin/liginf.cgi?id=$1",
     "prefix": "ligandbox",
-    "all_prefixes": [
+    "synonyms": [
       "ligandbox"
     ]
   },
@@ -6268,7 +6268,7 @@
     "preferred_prefix": "ligandexpo",
     "uri_format": "http://ligand-depot.rutgers.edu/pyapps/ldHandler.py?formid=cc-index-search&target=$1&operation=ccid",
     "prefix": "ligandexpo",
-    "all_prefixes": [
+    "synonyms": [
       "ligandexpo"
     ]
   },
@@ -6279,7 +6279,7 @@
     "preferred_prefix": "lincs.cell",
     "uri_format": "http://lincsportal.ccs.miami.edu/cells/#/view/$1",
     "prefix": "lincs.cell",
-    "all_prefixes": [
+    "synonyms": [
       "lincs.cell"
     ]
   },
@@ -6290,7 +6290,7 @@
     "preferred_prefix": "lincs.data",
     "uri_format": "http://lincsportal.ccs.miami.edu/datasets/#/view/$1",
     "prefix": "lincs.data",
-    "all_prefixes": [
+    "synonyms": [
       "lincs.data"
     ]
   },
@@ -6301,7 +6301,7 @@
     "preferred_prefix": "lincs.protein",
     "uri_format": "https://lincs.hms.harvard.edu/db/proteins/$1",
     "prefix": "lincs.protein",
-    "all_prefixes": [
+    "synonyms": [
       "lincs.protein"
     ]
   },
@@ -6312,7 +6312,7 @@
     "preferred_prefix": "lincs.smallmolecule",
     "uri_format": "http://lincsportal.ccs.miami.edu/SmallMolecules/#/view/$1",
     "prefix": "lincs.smallmolecule",
-    "all_prefixes": [
+    "synonyms": [
       "lincs",
       "lincs.smallmolecule"
     ]
@@ -6324,7 +6324,7 @@
     "preferred_prefix": "linguist",
     "uri_format": "https://raw.githubusercontent.com/github/linguist/master/lib/linguist/languages.yml#$1",
     "prefix": "linguist",
-    "all_prefixes": [
+    "synonyms": [
       "linguist"
     ]
   },
@@ -6335,7 +6335,7 @@
     "preferred_prefix": "lipidbank",
     "uri_format": "http://lipidbank.jp/cgi-bin/detail.cgi?id=$1",
     "prefix": "lipidbank",
-    "all_prefixes": [
+    "synonyms": [
       "lipidbank"
     ]
   },
@@ -6346,7 +6346,7 @@
     "preferred_prefix": "lipidmaps",
     "uri_format": "http://www.lipidmaps.org/data/LMSDRecord.php?LMID=$1",
     "prefix": "lipidmaps",
-    "all_prefixes": [
+    "synonyms": [
       "lipid_maps_class",
       "lipid_maps_instance",
       "lipidmaps"
@@ -6358,7 +6358,7 @@
     "preferred_prefix": "LIPRO",
     "uri_format": "http://purl.obolibrary.org/obo/LIPRO_$1",
     "prefix": "lipro",
-    "all_prefixes": [
+    "synonyms": [
       "lipro"
     ]
   },
@@ -6368,7 +6368,7 @@
     "preferred_prefix": "LOGGERHEAD",
     "uri_format": "http://purl.obolibrary.org/obo/LOGGERHEAD_$1",
     "prefix": "loggerhead",
-    "all_prefixes": [
+    "synonyms": [
       "loggerhead"
     ]
   },
@@ -6378,7 +6378,7 @@
     "preferred_prefix": "loinc",
     "uri_format": "https://loinc.org/$1",
     "prefix": "loinc",
-    "all_prefixes": [
+    "synonyms": [
       "loinc"
     ]
   },
@@ -6389,7 +6389,7 @@
     "preferred_prefix": "lotus",
     "uri_format": "https://lotus.naturalproducts.net/compound/lotus_id/$1",
     "prefix": "lotus",
-    "all_prefixes": [
+    "synonyms": [
       "lotus"
     ]
   },
@@ -6400,7 +6400,7 @@
     "preferred_prefix": "lrg",
     "uri_format": "ftp://ftp.ebi.ac.uk/pub/databases/lrgex/$1.xml",
     "prefix": "lrg",
-    "all_prefixes": [
+    "synonyms": [
       "lrg"
     ]
   },
@@ -6411,7 +6411,7 @@
     "preferred_prefix": "lspci",
     "uri_format": "https://labsyspharm.github.io/lspci/$1",
     "prefix": "lspci",
-    "all_prefixes": [
+    "synonyms": [
       "lspci"
     ]
   },
@@ -6422,7 +6422,7 @@
     "preferred_prefix": "MA",
     "uri_format": "http://www.informatics.jax.org/searches/AMA.cgi?id=MA:$1",
     "prefix": "ma",
-    "all_prefixes": [
+    "synonyms": [
       "ma"
     ]
   },
@@ -6433,7 +6433,7 @@
     "preferred_prefix": "macie",
     "uri_format": "https://www.ebi.ac.uk/thornton-srv/databases/cgi-bin/MACiE/entry/getPage.pl?id=$1",
     "prefix": "macie",
-    "all_prefixes": [
+    "synonyms": [
       "macie"
     ]
   },
@@ -6444,7 +6444,7 @@
     "preferred_prefix": "maizegdb.locus",
     "uri_format": "http://www.maizegdb.org/cgi-bin/displaylocusrecord.cgi?id=$1",
     "prefix": "maizegdb.locus",
-    "all_prefixes": [
+    "synonyms": [
       "maizegdb.locus"
     ]
   },
@@ -6455,7 +6455,7 @@
     "preferred_prefix": "MAMO",
     "uri_format": "http://purl.obolibrary.org/obo/MAMO_$1",
     "prefix": "mamo",
-    "all_prefixes": [
+    "synonyms": [
       "mamo"
     ]
   },
@@ -6465,7 +6465,7 @@
     "preferred_prefix": "MAO",
     "uri_format": "http://purl.obolibrary.org/obo/MAO_$1",
     "prefix": "mao",
-    "all_prefixes": [
+    "synonyms": [
       "mao"
     ]
   },
@@ -6476,7 +6476,7 @@
     "preferred_prefix": "massbank",
     "uri_format": "http://www.massbank.jp/RecordDisplay?id=$1",
     "prefix": "massbank",
-    "all_prefixes": [
+    "synonyms": [
       "massbank"
     ]
   },
@@ -6487,7 +6487,7 @@
     "preferred_prefix": "massive",
     "uri_format": "https://massive.ucsd.edu/ProteoSAFe/QueryMSV?id=$1",
     "prefix": "massive",
-    "all_prefixes": [
+    "synonyms": [
       "massive"
     ]
   },
@@ -6497,7 +6497,7 @@
     "preferred_prefix": "MAT",
     "uri_format": "http://purl.obolibrary.org/obo/MAT_$1",
     "prefix": "mat",
-    "all_prefixes": [
+    "synonyms": [
       "mat"
     ]
   },
@@ -6507,7 +6507,7 @@
     "preferred_prefix": "matrixdb",
     "uri_format": "http://matrixdb.univ-lyon1.fr/cgi-bin/current/newPort?type=biomolecule&value=$1",
     "prefix": "matrixdb",
-    "all_prefixes": [
+    "synonyms": [
       "matrixdb"
     ]
   },
@@ -6518,7 +6518,7 @@
     "preferred_prefix": "matrixdb.association",
     "uri_format": "http://matrixdb.univ-lyon1.fr//cgi-bin/current/newPort?type=association&value=$1&class=Association",
     "prefix": "matrixdb.association",
-    "all_prefixes": [
+    "synonyms": [
       "matrixdb.association"
     ]
   },
@@ -6528,7 +6528,7 @@
     "preferred_prefix": "MAXO",
     "uri_format": "http://purl.obolibrary.org/obo/MAXO_$1",
     "prefix": "maxo",
-    "all_prefixes": [
+    "synonyms": [
       "maxo"
     ]
   },
@@ -6539,7 +6539,7 @@
     "preferred_prefix": "MCO",
     "uri_format": "http://purl.obolibrary.org/obo/MCO_$1",
     "prefix": "mco",
-    "all_prefixes": [
+    "synonyms": [
       "mco"
     ]
   },
@@ -6550,7 +6550,7 @@
     "preferred_prefix": "mdm",
     "uri_format": "https://medical-data-models.org/forms/$1",
     "prefix": "mdm",
-    "all_prefixes": [
+    "synonyms": [
       "mdm"
     ]
   },
@@ -6561,7 +6561,7 @@
     "preferred_prefix": "meddra",
     "uri_format": "http://purl.bioontology.org/ontology/MEDDRA/$1",
     "prefix": "meddra",
-    "all_prefixes": [
+    "synonyms": [
       "meddra",
       "medra"
     ]
@@ -6573,7 +6573,7 @@
     "preferred_prefix": "medgen",
     "uri_format": "https://www.ncbi.nlm.nih.gov/medgen/$1",
     "prefix": "medgen",
-    "all_prefixes": [
+    "synonyms": [
       "medgen"
     ]
   },
@@ -6584,7 +6584,7 @@
     "preferred_prefix": "medlineplus",
     "uri_format": "http://www.nlm.nih.gov/medlineplus/ency/article/$1.htm",
     "prefix": "medlineplus",
-    "all_prefixes": [
+    "synonyms": [
       "medlineplus"
     ]
   },
@@ -6595,7 +6595,7 @@
     "preferred_prefix": "merops",
     "uri_format": "http://merops.sanger.ac.uk/cgi-bin/pepsum?mid=$1",
     "prefix": "merops",
-    "all_prefixes": [
+    "synonyms": [
       "merops"
     ]
   },
@@ -6606,7 +6606,7 @@
     "preferred_prefix": "merops.family",
     "uri_format": "http://merops.sanger.ac.uk/cgi-bin/famsum?family=$1",
     "prefix": "merops.family",
-    "all_prefixes": [
+    "synonyms": [
       "merops.family"
     ]
   },
@@ -6617,7 +6617,7 @@
     "preferred_prefix": "merops.inhibitor",
     "uri_format": "http://merops.sanger.ac.uk/cgi-bin/pepsum?id=$1",
     "prefix": "merops.inhibitor",
-    "all_prefixes": [
+    "synonyms": [
       "merops.inhibitor"
     ]
   },
@@ -6628,7 +6628,7 @@
     "preferred_prefix": "mesh",
     "uri_format": "https://meshb.nlm.nih.gov/record/ui?ui=$1",
     "prefix": "mesh",
-    "all_prefixes": [
+    "synonyms": [
       "mesh",
       "mesh_descriptor_ui",
       "mesh_supplemental_record_ui",
@@ -6647,7 +6647,7 @@
     "preferred_prefix": "mesh.2012",
     "uri_format": "http://www.nlm.nih.gov/cgi/mesh/2012/MB_cgi?mode=&index=$1&view=expanded",
     "prefix": "mesh.2012",
-    "all_prefixes": [
+    "synonyms": [
       "mesh.2012"
     ]
   },
@@ -6658,7 +6658,7 @@
     "preferred_prefix": "mesh.2013",
     "uri_format": "http://www.nlm.nih.gov/cgi/mesh/2013/MB_cgi?mode=&index=$1&view=expanded",
     "prefix": "mesh.2013",
-    "all_prefixes": [
+    "synonyms": [
       "mesh.2013"
     ]
   },
@@ -6669,7 +6669,7 @@
     "preferred_prefix": "metabolights",
     "uri_format": "https://www.ebi.ac.uk/metabolights/$1",
     "prefix": "metabolights",
-    "all_prefixes": [
+    "synonyms": [
       "metabolights"
     ]
   },
@@ -6680,7 +6680,7 @@
     "preferred_prefix": "metacyc.compound",
     "uri_format": "https://metacyc.org/compound?orgid=META&id=$1",
     "prefix": "metacyc.compound",
-    "all_prefixes": [
+    "synonyms": [
       "metacyc",
       "metacyc.compound"
     ]
@@ -6692,7 +6692,7 @@
     "preferred_prefix": "metacyc.reaction",
     "uri_format": "https://metacyc.org/META/NEW-IMAGE?type=REACTION&object=$1",
     "prefix": "metacyc.reaction",
-    "all_prefixes": [
+    "synonyms": [
       "metacyc.reaction"
     ]
   },
@@ -6703,7 +6703,7 @@
     "preferred_prefix": "metanetx.chemical",
     "uri_format": "https://www.metanetx.org/chem_info/$1",
     "prefix": "metanetx.chemical",
-    "all_prefixes": [
+    "synonyms": [
       "metanetx.chemical"
     ]
   },
@@ -6714,7 +6714,7 @@
     "preferred_prefix": "metanetx.compartment",
     "uri_format": "https://www.metanetx.org/comp_info/$1",
     "prefix": "metanetx.compartment",
-    "all_prefixes": [
+    "synonyms": [
       "metanetx.compartment"
     ]
   },
@@ -6725,7 +6725,7 @@
     "preferred_prefix": "metanetx.reaction",
     "uri_format": "https://www.metanetx.org/equa_info/$1",
     "prefix": "metanetx.reaction",
-    "all_prefixes": [
+    "synonyms": [
       "metanetx.reaction"
     ]
   },
@@ -6736,7 +6736,7 @@
     "preferred_prefix": "metlin",
     "uri_format": "http://metlin.scripps.edu/metabo_info.php?molid=$1",
     "prefix": "metlin",
-    "all_prefixes": [
+    "synonyms": [
       "metlin"
     ]
   },
@@ -6747,7 +6747,7 @@
     "preferred_prefix": "mex",
     "uri_format": "https://www.metabolome-express.org/datasetview.php?datasetid=$1",
     "prefix": "mex",
-    "all_prefixes": [
+    "synonyms": [
       "mex"
     ]
   },
@@ -6757,7 +6757,7 @@
     "preferred_prefix": "MF",
     "uri_format": "http://purl.obolibrary.org/obo/MF_$1",
     "prefix": "mf",
-    "all_prefixes": [
+    "synonyms": [
       "mf"
     ]
   },
@@ -6767,7 +6767,7 @@
     "preferred_prefix": "MFMO",
     "uri_format": "http://purl.obolibrary.org/obo/MFMO_$1",
     "prefix": "mfmo",
-    "all_prefixes": [
+    "synonyms": [
       "mfmo"
     ]
   },
@@ -6777,7 +6777,7 @@
     "preferred_prefix": "MFO",
     "uri_format": "http://purl.obolibrary.org/obo/MFO_$1",
     "prefix": "mfo",
-    "all_prefixes": [
+    "synonyms": [
       "mfo"
     ]
   },
@@ -6787,7 +6787,7 @@
     "preferred_prefix": "MFOEM",
     "uri_format": "http://purl.obolibrary.org/obo/MFOEM_$1",
     "prefix": "mfoem",
-    "all_prefixes": [
+    "synonyms": [
       "mfoem"
     ]
   },
@@ -6797,7 +6797,7 @@
     "preferred_prefix": "MFOMD",
     "uri_format": "http://purl.obolibrary.org/obo/MFOMD_$1",
     "prefix": "mfomd",
-    "all_prefixes": [
+    "synonyms": [
       "mfomd"
     ]
   },
@@ -6808,7 +6808,7 @@
     "preferred_prefix": "mge",
     "uri_format": "http://aclame.ulb.ac.be/perl/Aclame/Genomes/mge_view.cgi?view=info&id=mge:$1",
     "prefix": "mge",
-    "all_prefixes": [
+    "synonyms": [
       "mge"
     ]
   },
@@ -6819,7 +6819,7 @@
     "preferred_prefix": "MGI",
     "uri_format": "http://www.informatics.jax.org/accession/MGI:$1",
     "prefix": "mgi",
-    "all_prefixes": [
+    "synonyms": [
       "mgd",
       "mgi"
     ]
@@ -6831,7 +6831,7 @@
     "preferred_prefix": "mgnify.analysis",
     "uri_format": "https://www.ebi.ac.uk/metagenomics/analyses/$1",
     "prefix": "mgnify.analysis",
-    "all_prefixes": [
+    "synonyms": [
       "mgnify.analysis"
     ]
   },
@@ -6842,7 +6842,7 @@
     "preferred_prefix": "mgnify.proj",
     "uri_format": "https://www.ebi.ac.uk/metagenomics/projects/$1",
     "prefix": "mgnify.proj",
-    "all_prefixes": [
+    "synonyms": [
       "mgnify.proj"
     ]
   },
@@ -6853,7 +6853,7 @@
     "preferred_prefix": "mgnify.samp",
     "uri_format": "https://www.ebi.ac.uk/metagenomics/samples/$1",
     "prefix": "mgnify.samp",
-    "all_prefixes": [
+    "synonyms": [
       "mgnify.samp"
     ]
   },
@@ -6864,7 +6864,7 @@
     "preferred_prefix": "MI",
     "uri_format": "https://www.ebi.ac.uk/ols/ontologies/mi/terms?obo_id=MI:$1",
     "prefix": "mi",
-    "all_prefixes": [
+    "synonyms": [
       "mi",
       "psi-mi"
     ]
@@ -6875,7 +6875,7 @@
     "preferred_prefix": "MIAPA",
     "uri_format": "http://purl.obolibrary.org/obo/MIAPA_$1",
     "prefix": "miapa",
-    "all_prefixes": [
+    "synonyms": [
       "miapa"
     ]
   },
@@ -6885,7 +6885,7 @@
     "preferred_prefix": "MICRO",
     "uri_format": "http://purl.obolibrary.org/obo/MICRO_$1",
     "prefix": "micro",
-    "all_prefixes": [
+    "synonyms": [
       "micro"
     ]
   },
@@ -6896,7 +6896,7 @@
     "preferred_prefix": "microscope",
     "uri_format": "http://www.genoscope.cns.fr/agc/microscope/mage/info.php?id=$1",
     "prefix": "microscope",
-    "all_prefixes": [
+    "synonyms": [
       "microscope"
     ]
   },
@@ -6907,7 +6907,7 @@
     "preferred_prefix": "microsporidia",
     "uri_format": "http://microsporidiadb.org/micro/showRecord.do?name=GeneRecordClasses.GeneRecordClass&source_id=$1",
     "prefix": "microsporidia",
-    "all_prefixes": [
+    "synonyms": [
       "microsporidia"
     ]
   },
@@ -6918,7 +6918,7 @@
     "preferred_prefix": "mim",
     "uri_format": "https://omim.org/entry/$1",
     "prefix": "mim",
-    "all_prefixes": [
+    "synonyms": [
       "mim",
       "omim"
     ]
@@ -6929,7 +6929,7 @@
     "preferred_prefix": "mim.ps",
     "uri_format": "https://omim.org/phenotypicSeries/$1",
     "prefix": "mim.ps",
-    "all_prefixes": [
+    "synonyms": [
       "mim.ps",
       "omimps",
       "ps"
@@ -6942,7 +6942,7 @@
     "preferred_prefix": "mimodb",
     "uri_format": "http://immunet.cn/bdb/index.php/mimoset/$1",
     "prefix": "mimodb",
-    "all_prefixes": [
+    "synonyms": [
       "mimodb"
     ]
   },
@@ -6953,7 +6953,7 @@
     "preferred_prefix": "minid",
     "uri_format": "https://hdl.handle.net/hdl:20.500.12582/$1",
     "prefix": "minid",
-    "all_prefixes": [
+    "synonyms": [
       "minid"
     ]
   },
@@ -6964,7 +6964,7 @@
     "preferred_prefix": "minid.test",
     "uri_format": "https://hdl.handle.net/hdl:20.500.12633/$1",
     "prefix": "minid.test",
-    "all_prefixes": [
+    "synonyms": [
       "minid.test"
     ]
   },
@@ -6975,7 +6975,7 @@
     "preferred_prefix": "mint",
     "uri_format": "http://mint.bio.uniroma2.it/mint/search/inFrameInteraction.do?interactionAc=$1",
     "prefix": "mint",
-    "all_prefixes": [
+    "synonyms": [
       "mint"
     ]
   },
@@ -6986,7 +6986,7 @@
     "preferred_prefix": "mipmod",
     "uri_format": "http://bioinfo.iitk.ac.in/MIPModDB/result.php?code=$1",
     "prefix": "mipmod",
-    "all_prefixes": [
+    "synonyms": [
       "mipmod"
     ]
   },
@@ -6997,7 +6997,7 @@
     "preferred_prefix": "mir",
     "uri_format": "http://identifiers.org/mir/$1",
     "prefix": "mir",
-    "all_prefixes": [
+    "synonyms": [
       "mir"
     ]
   },
@@ -7008,7 +7008,7 @@
     "preferred_prefix": "mirbase",
     "uri_format": "http://www.mirbase.org/cgi-bin/mirna_entry.pl?acc=$1",
     "prefix": "mirbase",
-    "all_prefixes": [
+    "synonyms": [
       "mirbase"
     ]
   },
@@ -7018,7 +7018,7 @@
     "preferred_prefix": "mirbase.family",
     "uri_format": "http://www.mirbase.org/cgi-bin/mirna_summary.pl?fam=$1",
     "prefix": "mirbase.family",
-    "all_prefixes": [
+    "synonyms": [
       "mirbase.family",
       "mirbase_family"
     ]
@@ -7030,7 +7030,7 @@
     "preferred_prefix": "mirbase.mature",
     "uri_format": "http://mirbase.org/cgi-bin/mature.pl?mature_acc=$1",
     "prefix": "mirbase.mature",
-    "all_prefixes": [
+    "synonyms": [
       "mirbase.mature",
       "mirbasem"
     ]
@@ -7042,7 +7042,7 @@
     "preferred_prefix": "mirex",
     "uri_format": "http://comgen.pl/mirex1/?page=results/record&name=$1&exref=pp2a&limit=yes",
     "prefix": "mirex",
-    "all_prefixes": [
+    "synonyms": [
       "mirex"
     ]
   },
@@ -7054,7 +7054,7 @@
     "preferred_prefix": "miriam.collection",
     "uri_format": "https://www.ebi.ac.uk/miriam/main/$1",
     "prefix": "miriam.collection",
-    "all_prefixes": [
+    "synonyms": [
       "miriam.collection"
     ]
   },
@@ -7065,7 +7065,7 @@
     "preferred_prefix": "miriam.resource",
     "uri_format": "https://www.ebi.ac.uk/miriam/main/resources/$1",
     "prefix": "miriam.resource",
-    "all_prefixes": [
+    "synonyms": [
       "miriam.resource"
     ]
   },
@@ -7075,7 +7075,7 @@
     "preferred_prefix": "MIRNAO",
     "uri_format": "http://purl.obolibrary.org/obo/MIRNAO_$1",
     "prefix": "mirnao",
-    "all_prefixes": [
+    "synonyms": [
       "mirnao"
     ]
   },
@@ -7086,7 +7086,7 @@
     "preferred_prefix": "mirnest",
     "uri_format": "http://rhesus.amu.edu.pl/mirnest/copy/details.php?id=$1",
     "prefix": "mirnest",
-    "all_prefixes": [
+    "synonyms": [
       "mirnest"
     ]
   },
@@ -7097,7 +7097,7 @@
     "preferred_prefix": "MIRO",
     "uri_format": "http://purl.obolibrary.org/obo/MIRO_$1",
     "prefix": "miro",
-    "all_prefixes": [
+    "synonyms": [
       "miro"
     ]
   },
@@ -7108,7 +7108,7 @@
     "preferred_prefix": "mirtarbase",
     "uri_format": "http://mirtarbase.mbc.nctu.edu.tw/php/detail.php?mirtid=$1",
     "prefix": "mirtarbase",
-    "all_prefixes": [
+    "synonyms": [
       "mirtarbase"
     ]
   },
@@ -7119,7 +7119,7 @@
     "preferred_prefix": "mlc",
     "uri_format": "https://www.mlcommons.org/mlc-id/$1",
     "prefix": "mlc",
-    "all_prefixes": [
+    "synonyms": [
       "mlc"
     ]
   },
@@ -7130,7 +7130,7 @@
     "preferred_prefix": "mmdb",
     "uri_format": "http://www.ncbi.nlm.nih.gov/Structure/mmdb/mmdbsrv.cgi?uid=$1",
     "prefix": "mmdb",
-    "all_prefixes": [
+    "synonyms": [
       "mmdb"
     ]
   },
@@ -7141,7 +7141,7 @@
     "preferred_prefix": "mmmp.biomaps",
     "uri_format": "http://www.mmmp.org/MMMP/public/biomap/viewBiomap.mmmp?id=$1",
     "prefix": "mmmp.biomaps",
-    "all_prefixes": [
+    "synonyms": [
       "mmmp.biomaps"
     ]
   },
@@ -7152,7 +7152,7 @@
     "preferred_prefix": "MMO",
     "uri_format": "http://purl.obolibrary.org/obo/MMO_$1",
     "prefix": "mmo",
-    "all_prefixes": [
+    "synonyms": [
       "mmo"
     ]
   },
@@ -7163,7 +7163,7 @@
     "preferred_prefix": "mmp.cat",
     "uri_format": "https://mmp.sfb.uit.no/databases/marcat/#/records/$1",
     "prefix": "mmp.cat",
-    "all_prefixes": [
+    "synonyms": [
       "mmp.cat"
     ]
   },
@@ -7174,7 +7174,7 @@
     "preferred_prefix": "mmp.db",
     "uri_format": "https://mmp.sfb.uit.no/databases/mardb/#/records/$1",
     "prefix": "mmp.db",
-    "all_prefixes": [
+    "synonyms": [
       "mmp.db"
     ]
   },
@@ -7185,7 +7185,7 @@
     "preferred_prefix": "mmp.fun",
     "uri_format": "https://mmp.sfb.uit.no/databases/marfun/#/records/$1",
     "prefix": "mmp.fun",
-    "all_prefixes": [
+    "synonyms": [
       "mmp.fun"
     ]
   },
@@ -7196,7 +7196,7 @@
     "preferred_prefix": "mmp.ref",
     "uri_format": "https://mmp.sfb.uit.no/databases/marref/#/records/$1",
     "prefix": "mmp.ref",
-    "all_prefixes": [
+    "synonyms": [
       "mmp.ref"
     ]
   },
@@ -7207,7 +7207,7 @@
     "preferred_prefix": "mmrrc",
     "uri_format": "http://www.mmrrc.org/catalog/getSDS.php?mmrrc_id=$1",
     "prefix": "mmrrc",
-    "all_prefixes": [
+    "synonyms": [
       "mmrrc"
     ]
   },
@@ -7218,7 +7218,7 @@
     "preferred_prefix": "MmusDv",
     "uri_format": "http://purl.obolibrary.org/obo/MMUSDV_$1",
     "prefix": "mmusdv",
-    "all_prefixes": [
+    "synonyms": [
       "mmusdv"
     ]
   },
@@ -7230,7 +7230,7 @@
     "preferred_prefix": "MO",
     "uri_format": "http://purl.bioontology.org/ontology/MO/$1",
     "prefix": "mo",
-    "all_prefixes": [
+    "synonyms": [
       "mo"
     ]
   },
@@ -7241,7 +7241,7 @@
     "preferred_prefix": "mobidb",
     "uri_format": "https://mobidb.org/$1",
     "prefix": "mobidb",
-    "all_prefixes": [
+    "synonyms": [
       "mobidb"
     ]
   },
@@ -7252,7 +7252,7 @@
     "preferred_prefix": "MOD",
     "uri_format": "https://www.ebi.ac.uk/ols/ontologies/mod/terms?obo_id=MOD:$1",
     "prefix": "mod",
-    "all_prefixes": [
+    "synonyms": [
       "mod"
     ]
   },
@@ -7263,7 +7263,7 @@
     "preferred_prefix": "modeldb",
     "uri_format": "http://senselab.med.yale.edu/ModelDB/ShowModel.asp?model=$1",
     "prefix": "modeldb",
-    "all_prefixes": [
+    "synonyms": [
       "modeldb"
     ]
   },
@@ -7274,7 +7274,7 @@
     "preferred_prefix": "molbase",
     "uri_format": "http://www.molbase.com/en/index.php?app=search&search_keyword=$1",
     "prefix": "molbase",
-    "all_prefixes": [
+    "synonyms": [
       "molbase"
     ]
   },
@@ -7285,7 +7285,7 @@
     "preferred_prefix": "molmedb",
     "uri_format": "https://molmedb.upol.cz/mol/$1",
     "prefix": "molmedb",
-    "all_prefixes": [
+    "synonyms": [
       "molmedb"
     ]
   },
@@ -7296,7 +7296,7 @@
     "preferred_prefix": "MONDO",
     "uri_format": "http://purl.obolibrary.org/obo/MONDO_$1",
     "prefix": "mondo",
-    "all_prefixes": [
+    "synonyms": [
       "mondo"
     ]
   },
@@ -7307,7 +7307,7 @@
     "preferred_prefix": "MOP",
     "uri_format": "http://purl.obolibrary.org/obo/MOP_$1",
     "prefix": "mop",
-    "all_prefixes": [
+    "synonyms": [
       "mop"
     ]
   },
@@ -7318,7 +7318,7 @@
     "preferred_prefix": "morpheus",
     "uri_format": "https://morpheus.gitlab.io/models/$1",
     "prefix": "morpheus",
-    "all_prefixes": [
+    "synonyms": [
       "morpheus"
     ]
   },
@@ -7329,7 +7329,7 @@
     "preferred_prefix": "MP",
     "uri_format": "http://www.informatics.jax.org/searches/Phat.cgi?id=MP:$1",
     "prefix": "mp",
-    "all_prefixes": [
+    "synonyms": [
       "mp"
     ]
   },
@@ -7340,7 +7340,7 @@
     "preferred_prefix": "MPATH",
     "uri_format": "http://purl.obolibrary.org/obo/MPATH_$1",
     "prefix": "mpath",
-    "all_prefixes": [
+    "synonyms": [
       "mpath"
     ]
   },
@@ -7351,7 +7351,7 @@
     "preferred_prefix": "mpid",
     "uri_format": "http://www.jcvi.org/mpidb/experiment.php?interaction_id=$1",
     "prefix": "mpid",
-    "all_prefixes": [
+    "synonyms": [
       "mpid"
     ]
   },
@@ -7361,7 +7361,7 @@
     "preferred_prefix": "MPIO",
     "uri_format": "http://purl.obolibrary.org/obo/MPIO_$1",
     "prefix": "mpio",
-    "all_prefixes": [
+    "synonyms": [
       "mpio"
     ]
   },
@@ -7371,7 +7371,7 @@
     "preferred_prefix": "MRO",
     "uri_format": "http://purl.obolibrary.org/obo/MRO_$1",
     "prefix": "mro",
-    "all_prefixes": [
+    "synonyms": [
       "mro"
     ]
   },
@@ -7382,7 +7382,7 @@
     "preferred_prefix": "MS",
     "uri_format": "https://www.ebi.ac.uk/ols/ontologies/ms/terms?obo_id=MS:$1",
     "prefix": "ms",
-    "all_prefixes": [
+    "synonyms": [
       "ms"
     ]
   },
@@ -7392,7 +7392,7 @@
     "preferred_prefix": "multicellds",
     "uri_format": "http://multicellds.org/MultiCellDB/$1",
     "prefix": "multicellds",
-    "all_prefixes": [
+    "synonyms": [
       "multicellds"
     ]
   },
@@ -7403,7 +7403,7 @@
     "preferred_prefix": "multicellds.cell_line",
     "uri_format": "http://multicellds.org/MultiCellDB/$1",
     "prefix": "multicellds.cell_line",
-    "all_prefixes": [
+    "synonyms": [
       "multicellds.cell_line"
     ]
   },
@@ -7414,7 +7414,7 @@
     "preferred_prefix": "multicellds.collection",
     "uri_format": "http://multicellds.org/MultiCellDB/$1",
     "prefix": "multicellds.collection",
-    "all_prefixes": [
+    "synonyms": [
       "multicellds.collection"
     ]
   },
@@ -7425,7 +7425,7 @@
     "preferred_prefix": "multicellds.snapshot",
     "uri_format": "http://multicellds.org/MultiCellDB/$1",
     "prefix": "multicellds.snapshot",
-    "all_prefixes": [
+    "synonyms": [
       "multicellds.snapshot"
     ]
   },
@@ -7436,7 +7436,7 @@
     "preferred_prefix": "mw.project",
     "uri_format": "http://www.metabolomicsworkbench.org/data/DRCCMetadata.php?Mode=Project&ProjectID=$1",
     "prefix": "mw.project",
-    "all_prefixes": [
+    "synonyms": [
       "mw.project"
     ]
   },
@@ -7447,7 +7447,7 @@
     "preferred_prefix": "mw.study",
     "uri_format": "http://www.metabolomicsworkbench.org/data/DRCCMetadata.php?Mode=Study&StudyID=$1",
     "prefix": "mw.study",
-    "all_prefixes": [
+    "synonyms": [
       "mw.study"
     ]
   },
@@ -7458,7 +7458,7 @@
     "preferred_prefix": "myco.lepra",
     "uri_format": "http://mycobrowser.epfl.ch/leprosysearch.php?gene+name=$1",
     "prefix": "myco.lepra",
-    "all_prefixes": [
+    "synonyms": [
       "myco.lepra"
     ]
   },
@@ -7469,7 +7469,7 @@
     "preferred_prefix": "myco.marinum",
     "uri_format": "http://mycobrowser.epfl.ch/marinosearch.php?gene+name=$1",
     "prefix": "myco.marinum",
-    "all_prefixes": [
+    "synonyms": [
       "myco.marinum"
     ]
   },
@@ -7480,7 +7480,7 @@
     "preferred_prefix": "myco.smeg",
     "uri_format": "http://mycobrowser.epfl.ch/smegmasearch.php?gene+name=$1",
     "prefix": "myco.smeg",
-    "all_prefixes": [
+    "synonyms": [
       "myco.smeg"
     ]
   },
@@ -7491,7 +7491,7 @@
     "preferred_prefix": "myco.tuber",
     "uri_format": "http://tuberculist.epfl.ch/quicksearch.php?gene+name=$1",
     "prefix": "myco.tuber",
-    "all_prefixes": [
+    "synonyms": [
       "myco.tuber"
     ]
   },
@@ -7502,7 +7502,7 @@
     "preferred_prefix": "mycobank",
     "uri_format": "http://www.mycobank.org/Biolomics.aspx?Table=Mycobank&MycoBankNr_=$1",
     "prefix": "mycobank",
-    "all_prefixes": [
+    "synonyms": [
       "mycobank"
     ]
   },
@@ -7513,7 +7513,7 @@
     "preferred_prefix": "mzspec",
     "uri_format": "http://proteomecentral.proteomexchange.org/usi/?usi=mzspec:$1",
     "prefix": "mzspec",
-    "all_prefixes": [
+    "synonyms": [
       "mzspec"
     ]
   },
@@ -7524,7 +7524,7 @@
     "preferred_prefix": "napdi",
     "uri_format": "https://repo.napdi.org/study/$1",
     "prefix": "napdi",
-    "all_prefixes": [
+    "synonyms": [
       "napdi"
     ]
   },
@@ -7535,7 +7535,7 @@
     "preferred_prefix": "napp",
     "uri_format": "http://rna.igmors.u-psud.fr/NAPP/Niveau2.php?specie=$1",
     "prefix": "napp",
-    "all_prefixes": [
+    "synonyms": [
       "napp"
     ]
   },
@@ -7546,7 +7546,7 @@
     "preferred_prefix": "narcis",
     "uri_format": "http://www.narcis.nl/publication/RecordID/$1",
     "prefix": "narcis",
-    "all_prefixes": [
+    "synonyms": [
       "narcis"
     ]
   },
@@ -7557,7 +7557,7 @@
     "preferred_prefix": "nasc",
     "uri_format": "http://arabidopsis.info/StockInfo?NASC_id=$1",
     "prefix": "nasc",
-    "all_prefixes": [
+    "synonyms": [
       "nasc"
     ]
   },
@@ -7568,7 +7568,7 @@
     "preferred_prefix": "nbn",
     "uri_format": "http://nbn-resolving.org/resolver?identifier=$1&verb=redirect",
     "prefix": "nbn",
-    "all_prefixes": [
+    "synonyms": [
       "nbn"
     ]
   },
@@ -7579,7 +7579,7 @@
     "preferred_prefix": "NBO",
     "uri_format": "http://purl.obolibrary.org/obo/NBO_$1",
     "prefix": "nbo",
-    "all_prefixes": [
+    "synonyms": [
       "nbo"
     ]
   },
@@ -7590,7 +7590,7 @@
     "preferred_prefix": "nbrc",
     "uri_format": "http://www.nbrc.nite.go.jp/NBRC2/NBRCCatalogueDetailServlet?ID=NBRC&CAT=$1",
     "prefix": "nbrc",
-    "all_prefixes": [
+    "synonyms": [
       "nbrc"
     ]
   },
@@ -7600,7 +7600,7 @@
     "preferred_prefix": "ncats.drug",
     "uri_format": "https://drugs.ncats.io/drug/$1",
     "prefix": "ncats.drug",
-    "all_prefixes": [
+    "synonyms": [
       "ncats.drug"
     ]
   },
@@ -7611,7 +7611,7 @@
     "preferred_prefix": "NCBIGene",
     "uri_format": "https://www.ncbi.nlm.nih.gov/gene/$1",
     "prefix": "ncbigene",
-    "all_prefixes": [
+    "synonyms": [
       "egid",
       "entrez",
       "ncbigene"
@@ -7624,7 +7624,7 @@
     "preferred_prefix": "NCBIProtein",
     "uri_format": "https://www.ncbi.nlm.nih.gov/protein/$1",
     "prefix": "ncbiprotein",
-    "all_prefixes": [
+    "synonyms": [
       "ncbiprotein"
     ]
   },
@@ -7635,7 +7635,7 @@
     "preferred_prefix": "NCBITaxon",
     "uri_format": "https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=$1",
     "prefix": "ncbitaxon",
-    "all_prefixes": [
+    "synonyms": [
       "ncbi_taxid",
       "ncbi_taxon_id",
       "ncbitaxon",
@@ -7653,7 +7653,7 @@
     "preferred_prefix": "ncim",
     "uri_format": "http://ncim.nci.nih.gov/ncimbrowser/ConceptReport.jsp?dictionary=NCI%20MetaThesaurus&code=$1",
     "prefix": "ncim",
-    "all_prefixes": [
+    "synonyms": [
       "ncim"
     ]
   },
@@ -7664,7 +7664,7 @@
     "preferred_prefix": "NCIT",
     "uri_format": "http://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI%20Thesaurus&code=$1",
     "prefix": "ncit",
-    "all_prefixes": [
+    "synonyms": [
       "nci",
       "nci2004_11_17",
       "nci_thesaurus",
@@ -7681,7 +7681,7 @@
     "preferred_prefix": "NCRO",
     "uri_format": "http://purl.obolibrary.org/obo/NCRO_$1",
     "prefix": "ncro",
-    "all_prefixes": [
+    "synonyms": [
       "ncro"
     ]
   },
@@ -7692,7 +7692,7 @@
     "preferred_prefix": "ndc",
     "uri_format": "http://www.hipaaspace.com/Medical_Billing/Coding/National.Drug.Codes/$1",
     "prefix": "ndc",
-    "all_prefixes": [
+    "synonyms": [
       "ndc"
     ]
   },
@@ -7702,7 +7702,7 @@
     "preferred_prefix": "ndex",
     "uri_format": "https://www.ndexbio.org/viewer/networks/$1",
     "prefix": "ndex",
-    "all_prefixes": [
+    "synonyms": [
       "ndex"
     ]
   },
@@ -7713,7 +7713,7 @@
     "preferred_prefix": "nemo",
     "uri_format": "https://assets.nemoarchive.org/$1",
     "prefix": "nemo",
-    "all_prefixes": [
+    "synonyms": [
       "nemo"
     ]
   },
@@ -7724,7 +7724,7 @@
     "preferred_prefix": "neurolex",
     "uri_format": "http://www.neurolex.org/wiki/$1",
     "prefix": "neurolex",
-    "all_prefixes": [
+    "synonyms": [
       "neurolex"
     ]
   },
@@ -7735,7 +7735,7 @@
     "preferred_prefix": "neuromorpho",
     "uri_format": "http://neuromorpho.org/neuron_info.jsp?neuron_name=$1",
     "prefix": "neuromorpho",
-    "all_prefixes": [
+    "synonyms": [
       "neuromorpho"
     ]
   },
@@ -7745,7 +7745,7 @@
     "preferred_prefix": "neuronames",
     "uri_format": "https://braininfo.rprc.washington.edu/centraldirectory.aspx?ID=$1",
     "prefix": "neuronames",
-    "all_prefixes": [
+    "synonyms": [
       "neuroname",
       "neuronames"
     ]
@@ -7757,7 +7757,7 @@
     "preferred_prefix": "neurondb",
     "uri_format": "http://senselab.med.yale.edu/NeuronDB/NeuronProp.aspx?id=$1",
     "prefix": "neurondb",
-    "all_prefixes": [
+    "synonyms": [
       "neurondb"
     ]
   },
@@ -7768,7 +7768,7 @@
     "preferred_prefix": "neurovault.collection",
     "uri_format": "https://neurovault.org/collections/$1",
     "prefix": "neurovault.collection",
-    "all_prefixes": [
+    "synonyms": [
       "neurovault.collection"
     ]
   },
@@ -7779,7 +7779,7 @@
     "preferred_prefix": "neurovault.image",
     "uri_format": "https://neurovault.org/images/$1",
     "prefix": "neurovault.image",
-    "all_prefixes": [
+    "synonyms": [
       "neurovault.image"
     ]
   },
@@ -7790,7 +7790,7 @@
     "preferred_prefix": "nextdb",
     "uri_format": "http://nematode.lab.nig.ac.jp/db2/ShowCloneInfo.php?clone=$1",
     "prefix": "nextdb",
-    "all_prefixes": [
+    "synonyms": [
       "nextdb"
     ]
   },
@@ -7801,7 +7801,7 @@
     "preferred_prefix": "nextprot",
     "uri_format": "https://www.nextprot.org/db/entry/$1",
     "prefix": "nextprot",
-    "all_prefixes": [
+    "synonyms": [
       "nextprot",
       "nxp"
     ]
@@ -7813,7 +7813,7 @@
     "preferred_prefix": "nextprot.family",
     "uri_format": "https://www.nextprot.org/term/FA-$1",
     "prefix": "nextprot.family",
-    "all_prefixes": [
+    "synonyms": [
       "nextprot.family",
       "nxpfa"
     ]
@@ -7825,7 +7825,7 @@
     "preferred_prefix": "ngl",
     "uri_format": "https://genelab-data.ndc.nasa.gov/genelab/accession/$1",
     "prefix": "ngl",
-    "all_prefixes": [
+    "synonyms": [
       "ngl"
     ]
   },
@@ -7836,7 +7836,7 @@
     "preferred_prefix": "niaest",
     "uri_format": "http://lgsun.grc.nia.nih.gov/cgi-bin/pro3?sname1=$1",
     "prefix": "niaest",
-    "all_prefixes": [
+    "synonyms": [
       "niaest"
     ]
   },
@@ -7846,7 +7846,7 @@
     "preferred_prefix": "NIF_CELL",
     "uri_format": "http://purl.obolibrary.org/obo/NIF_CELL_$1",
     "prefix": "nif_cell",
-    "all_prefixes": [
+    "synonyms": [
       "nif_cell"
     ]
   },
@@ -7856,7 +7856,7 @@
     "preferred_prefix": "NIF_DYSFUNCTION",
     "uri_format": "http://purl.obolibrary.org/obo/NIF_DYSFUNCTION_$1",
     "prefix": "nif_dysfunction",
-    "all_prefixes": [
+    "synonyms": [
       "nif_dysfunction"
     ]
   },
@@ -7866,7 +7866,7 @@
     "preferred_prefix": "NIF_GROSSANATOMY",
     "uri_format": "http://purl.obolibrary.org/obo/NIF_GROSSANATOMY_$1",
     "prefix": "nif_grossanatomy",
-    "all_prefixes": [
+    "synonyms": [
       "nif_grossanatomy"
     ]
   },
@@ -7876,7 +7876,7 @@
     "preferred_prefix": "nlm",
     "uri_format": "https://www.ncbi.nlm.nih.gov/nlmcatalog/$1",
     "prefix": "nlm",
-    "all_prefixes": [
+    "synonyms": [
       "nlm"
     ]
   },
@@ -7886,7 +7886,7 @@
     "preferred_prefix": "nlxanat",
     "uri_format": "http://uri.neuinfo.org/nif/nifstd/nlx_anat_$1",
     "prefix": "nlxanat",
-    "all_prefixes": [
+    "synonyms": [
       "nlxanat"
     ]
   },
@@ -7896,7 +7896,7 @@
     "preferred_prefix": "nlxdys",
     "uri_format": "http://uri.neuinfo.org/nif/nifstd/nlx_dys_$1",
     "prefix": "nlxdys",
-    "all_prefixes": [
+    "synonyms": [
       "nlxdys"
     ]
   },
@@ -7907,7 +7907,7 @@
     "preferred_prefix": "nmdc",
     "uri_format": "https://drs.microbiomedata.org/objects/$1",
     "prefix": "nmdc",
-    "all_prefixes": [
+    "synonyms": [
       "nmdc"
     ]
   },
@@ -7919,7 +7919,7 @@
     "preferred_prefix": "NMR",
     "uri_format": "https://www.ebi.ac.uk/ols/ontologies/nmrcv/terms?short_form=NMR:$1",
     "prefix": "nmr",
-    "all_prefixes": [
+    "synonyms": [
       "nmr",
       "nmrcv"
     ]
@@ -7931,7 +7931,7 @@
     "preferred_prefix": "nmrshiftdb2",
     "uri_format": "https://nmrshiftdb.nmr.uni-koeln.de/molecule/$1",
     "prefix": "nmrshiftdb2",
-    "all_prefixes": [
+    "synonyms": [
       "nmrshiftdb2"
     ]
   },
@@ -7941,7 +7941,7 @@
     "preferred_prefix": "NOMEN",
     "uri_format": "http://purl.obolibrary.org/obo/NOMEN_$1",
     "prefix": "nomen",
-    "all_prefixes": [
+    "synonyms": [
       "nomen"
     ]
   },
@@ -7952,7 +7952,7 @@
     "preferred_prefix": "noncodev3",
     "uri_format": "http://www.noncode.org/NONCODERv3/ncrna.php?ncid=$1",
     "prefix": "noncodev3",
-    "all_prefixes": [
+    "synonyms": [
       "noncodev3"
     ]
   },
@@ -7963,7 +7963,7 @@
     "preferred_prefix": "noncodev4.gene",
     "uri_format": "http://www.bioinfo.org/NONCODEv4/show_gene.php?id=$1",
     "prefix": "noncodev4.gene",
-    "all_prefixes": [
+    "synonyms": [
       "noncodev4.gene"
     ]
   },
@@ -7974,7 +7974,7 @@
     "preferred_prefix": "noncodev4.rna",
     "uri_format": "http://www.bioinfo.org/NONCODEv4/show_rna.php?id=$1",
     "prefix": "noncodev4.rna",
-    "all_prefixes": [
+    "synonyms": [
       "noncodev4.rna"
     ]
   },
@@ -7985,7 +7985,7 @@
     "preferred_prefix": "norine",
     "uri_format": "http://bioinfo.lifl.fr/norine/result.jsp?ID=$1",
     "prefix": "norine",
-    "all_prefixes": [
+    "synonyms": [
       "norine"
     ]
   },
@@ -7995,7 +7995,7 @@
     "preferred_prefix": "novus",
     "uri_format": "https://www.novusbio.com/products/$1",
     "prefix": "novus",
-    "all_prefixes": [
+    "synonyms": [
       "novus"
     ]
   },
@@ -8006,7 +8006,7 @@
     "preferred_prefix": "nuclearbd",
     "uri_format": "http://www.receptors.org/nucleardb/proteins/$1",
     "prefix": "nuclearbd",
-    "all_prefixes": [
+    "synonyms": [
       "nuclearbd"
     ]
   },
@@ -8017,7 +8017,7 @@
     "preferred_prefix": "nucleotide",
     "uri_format": "https://www.ncbi.nlm.nih.gov/nuccore/$1",
     "prefix": "nucleotide",
-    "all_prefixes": [
+    "synonyms": [
       "nucleotide"
     ]
   },
@@ -8027,7 +8027,7 @@
     "preferred_prefix": "oa",
     "uri_format": "http://www.w3.org/ns/oa#$1",
     "prefix": "oa",
-    "all_prefixes": [
+    "synonyms": [
       "oa"
     ]
   },
@@ -8037,7 +8037,7 @@
     "preferred_prefix": "OAE",
     "uri_format": "http://purl.obolibrary.org/obo/OAE_$1",
     "prefix": "oae",
-    "all_prefixes": [
+    "synonyms": [
       "oae"
     ]
   },
@@ -8047,7 +8047,7 @@
     "preferred_prefix": "OARCS",
     "uri_format": "http://purl.obolibrary.org/obo/OARCS_$1",
     "prefix": "oarcs",
-    "all_prefixes": [
+    "synonyms": [
       "oarcs"
     ]
   },
@@ -8058,7 +8058,7 @@
     "preferred_prefix": "OBA",
     "uri_format": "http://purl.obolibrary.org/obo/OBA_$1",
     "prefix": "oba",
-    "all_prefixes": [
+    "synonyms": [
       "oba"
     ]
   },
@@ -8068,7 +8068,7 @@
     "preferred_prefix": "OBCS",
     "uri_format": "http://purl.obolibrary.org/obo/OBCS_$1",
     "prefix": "obcs",
-    "all_prefixes": [
+    "synonyms": [
       "obcs"
     ]
   },
@@ -8079,7 +8079,7 @@
     "preferred_prefix": "OBI",
     "uri_format": "http://purl.obolibrary.org/obo/OBI_$1",
     "prefix": "obi",
-    "all_prefixes": [
+    "synonyms": [
       "obi"
     ]
   },
@@ -8089,7 +8089,7 @@
     "preferred_prefix": "OBIB",
     "uri_format": "http://purl.obolibrary.org/obo/OBIB_$1",
     "prefix": "obib",
-    "all_prefixes": [
+    "synonyms": [
       "obib"
     ]
   },
@@ -8098,7 +8098,7 @@
     "preferred_prefix": "obo",
     "uri_format": "http://purl.obolibrary.org/obo/$1",
     "prefix": "obo",
-    "all_prefixes": [
+    "synonyms": [
       "obo"
     ]
   },
@@ -8108,7 +8108,7 @@
     "preferred_prefix": "oboInOwl",
     "uri_format": "http://www.geneontology.org/formats/oboInOwl#$1",
     "prefix": "oboinowl",
-    "all_prefixes": [
+    "synonyms": [
       "oboinowl",
       "oio"
     ]
@@ -8120,7 +8120,7 @@
     "preferred_prefix": "occ",
     "uri_format": "https://w3id.org/oc/corpus/$1",
     "prefix": "occ",
-    "all_prefixes": [
+    "synonyms": [
       "occ"
     ]
   },
@@ -8131,7 +8131,7 @@
     "preferred_prefix": "oci",
     "uri_format": "https://w3id.org/oc/oci/$1",
     "prefix": "oci",
-    "all_prefixes": [
+    "synonyms": [
       "oci"
     ]
   },
@@ -8142,7 +8142,7 @@
     "preferred_prefix": "ocid",
     "uri_format": "https://ocid.ontochem.com/prefname?ocid=$1",
     "prefix": "ocid",
-    "all_prefixes": [
+    "synonyms": [
       "ocid"
     ]
   },
@@ -8153,7 +8153,7 @@
     "preferred_prefix": "oclc",
     "uri_format": "https://www.worldcat.org/oclc/$1",
     "prefix": "oclc",
-    "all_prefixes": [
+    "synonyms": [
       "oclc"
     ]
   },
@@ -8164,7 +8164,7 @@
     "preferred_prefix": "odam",
     "uri_format": "http://pmb-bordeaux.fr/getdata/json/$1/datapackage?links=1",
     "prefix": "odam",
-    "all_prefixes": [
+    "synonyms": [
       "odam"
     ]
   },
@@ -8175,7 +8175,7 @@
     "preferred_prefix": "odc.sci",
     "uri_format": "https://odc-sci.org/data/$1",
     "prefix": "odc.sci",
-    "all_prefixes": [
+    "synonyms": [
       "odc.sci"
     ]
   },
@@ -8186,7 +8186,7 @@
     "preferred_prefix": "odc.tbi",
     "uri_format": "https://odc-tbi.org/data/$1",
     "prefix": "odc.tbi",
-    "all_prefixes": [
+    "synonyms": [
       "odc.tbi"
     ]
   },
@@ -8197,7 +8197,7 @@
     "preferred_prefix": "odor",
     "uri_format": "http://senselab.med.yale.edu/OdorDB/Data/$1/?db=5",
     "prefix": "odor",
-    "all_prefixes": [
+    "synonyms": [
       "odor"
     ]
   },
@@ -8207,7 +8207,7 @@
     "preferred_prefix": "OGG",
     "uri_format": "http://purl.obolibrary.org/obo/OGG_$1",
     "prefix": "ogg",
-    "all_prefixes": [
+    "synonyms": [
       "ogg"
     ]
   },
@@ -8217,7 +8217,7 @@
     "preferred_prefix": "OGI",
     "uri_format": "http://purl.obolibrary.org/obo/OGI_$1",
     "prefix": "ogi",
-    "all_prefixes": [
+    "synonyms": [
       "ogi"
     ]
   },
@@ -8227,7 +8227,7 @@
     "preferred_prefix": "OGMS",
     "uri_format": "http://purl.obolibrary.org/obo/OGMS_$1",
     "prefix": "ogms",
-    "all_prefixes": [
+    "synonyms": [
       "ogms"
     ]
   },
@@ -8237,7 +8237,7 @@
     "preferred_prefix": "OGSF",
     "uri_format": "http://purl.obolibrary.org/obo/OGSF_$1",
     "prefix": "ogsf",
-    "all_prefixes": [
+    "synonyms": [
       "ogsf"
     ]
   },
@@ -8247,7 +8247,7 @@
     "preferred_prefix": "OHD",
     "uri_format": "http://purl.obolibrary.org/obo/OHD_$1",
     "prefix": "ohd",
-    "all_prefixes": [
+    "synonyms": [
       "ohd"
     ]
   },
@@ -8257,7 +8257,7 @@
     "preferred_prefix": "OHMI",
     "uri_format": "http://purl.obolibrary.org/obo/OHMI_$1",
     "prefix": "ohmi",
-    "all_prefixes": [
+    "synonyms": [
       "ohmi"
     ]
   },
@@ -8267,7 +8267,7 @@
     "preferred_prefix": "OHPI",
     "uri_format": "http://purl.obolibrary.org/obo/OHPI_$1",
     "prefix": "ohpi",
-    "all_prefixes": [
+    "synonyms": [
       "ohpi"
     ]
   },
@@ -8278,7 +8278,7 @@
     "preferred_prefix": "oid",
     "uri_format": "http://www.oid-info.com/cgi-bin/display?oid=$1&submit=Display&action=display",
     "prefix": "oid",
-    "all_prefixes": [
+    "synonyms": [
       "oid"
     ]
   },
@@ -8289,7 +8289,7 @@
     "preferred_prefix": "OlatDv",
     "uri_format": "http://purl.obolibrary.org/obo/OLATDV_$1",
     "prefix": "olatdv",
-    "all_prefixes": [
+    "synonyms": [
       "olatdv"
     ]
   },
@@ -8300,7 +8300,7 @@
     "preferred_prefix": "oma.grp",
     "uri_format": "https://omabrowser.org/cgi-bin/gateway.pl?f=DisplayGroup&p1=$1",
     "prefix": "oma.grp",
-    "all_prefixes": [
+    "synonyms": [
       "oma.grp"
     ]
   },
@@ -8311,7 +8311,7 @@
     "preferred_prefix": "oma.hog",
     "uri_format": "https://omabrowser.org/oma/hog/HOG:$1",
     "prefix": "oma.hog",
-    "all_prefixes": [
+    "synonyms": [
       "oma.hog"
     ]
   },
@@ -8322,7 +8322,7 @@
     "preferred_prefix": "oma.protein",
     "uri_format": "https://omabrowser.org/cgi-bin/gateway.pl?f=DisplayEntry&p1=$1",
     "prefix": "oma.protein",
-    "all_prefixes": [
+    "synonyms": [
       "oma.protein"
     ]
   },
@@ -8334,7 +8334,7 @@
     "preferred_prefix": "omia",
     "uri_format": "http://omia.angis.org.au/$1/",
     "prefix": "omia",
-    "all_prefixes": [
+    "synonyms": [
       "omia"
     ]
   },
@@ -8345,7 +8345,7 @@
     "preferred_prefix": "OMIABIS",
     "uri_format": "http://purl.obolibrary.org/obo/OMIABIS_$1",
     "prefix": "omiabis",
-    "all_prefixes": [
+    "synonyms": [
       "omiabis"
     ]
   },
@@ -8356,7 +8356,7 @@
     "preferred_prefix": "OMIT",
     "uri_format": "https://www.ebi.ac.uk/ols/ontologies/omit/terms?short_form=OMIT_$1",
     "prefix": "omit",
-    "all_prefixes": [
+    "synonyms": [
       "omit"
     ]
   },
@@ -8365,7 +8365,7 @@
     "preferred_prefix": "OMO",
     "uri_format": "http://purl.obolibrary.org/obo/OMO_$1",
     "prefix": "omo",
-    "all_prefixes": [
+    "synonyms": [
       "omo"
     ]
   },
@@ -8376,7 +8376,7 @@
     "preferred_prefix": "OMP",
     "uri_format": "http://purl.obolibrary.org/obo/OMP_$1",
     "prefix": "omp",
-    "all_prefixes": [
+    "synonyms": [
       "omp"
     ]
   },
@@ -8386,7 +8386,7 @@
     "preferred_prefix": "OMRSE",
     "uri_format": "http://purl.obolibrary.org/obo/OMRSE_$1",
     "prefix": "omrse",
-    "all_prefixes": [
+    "synonyms": [
       "omrse"
     ]
   },
@@ -8396,7 +8396,7 @@
     "preferred_prefix": "oncotree",
     "uri_format": "http://oncotree.mskcc.org/api/tumorTypes/search/code/$1",
     "prefix": "oncotree",
-    "all_prefixes": [
+    "synonyms": [
       "oncotree"
     ]
   },
@@ -8406,7 +8406,7 @@
     "preferred_prefix": "ONE",
     "uri_format": "http://purl.obolibrary.org/obo/ONE_$1",
     "prefix": "one",
-    "all_prefixes": [
+    "synonyms": [
       "one"
     ]
   },
@@ -8416,7 +8416,7 @@
     "preferred_prefix": "ONS",
     "uri_format": "http://purl.obolibrary.org/obo/ONS_$1",
     "prefix": "ons",
-    "all_prefixes": [
+    "synonyms": [
       "ons"
     ]
   },
@@ -8426,7 +8426,7 @@
     "preferred_prefix": "ONTONEO",
     "uri_format": "http://purl.obolibrary.org/obo/ONTONEO_$1",
     "prefix": "ontoneo",
-    "all_prefixes": [
+    "synonyms": [
       "ontoneo"
     ]
   },
@@ -8436,7 +8436,7 @@
     "preferred_prefix": "OOSTT",
     "uri_format": "http://purl.obolibrary.org/obo/OOSTT_$1",
     "prefix": "oostt",
-    "all_prefixes": [
+    "synonyms": [
       "oostt"
     ]
   },
@@ -8447,7 +8447,7 @@
     "preferred_prefix": "opb",
     "uri_format": "http://purl.bioontology.org/ontology/OPB?conceptid=http%3A%2F%2Fbhi.washington.edu%2FOPB%23$1",
     "prefix": "opb",
-    "all_prefixes": [
+    "synonyms": [
       "opb"
     ]
   },
@@ -8457,7 +8457,7 @@
     "preferred_prefix": "OPL",
     "uri_format": "http://purl.obolibrary.org/obo/OPL_$1",
     "prefix": "opl",
-    "all_prefixes": [
+    "synonyms": [
       "opl"
     ]
   },
@@ -8468,7 +8468,7 @@
     "preferred_prefix": "opm",
     "uri_format": "http://opm.phar.umich.edu/protein.php?pdbid=$1",
     "prefix": "opm",
-    "all_prefixes": [
+    "synonyms": [
       "opm"
     ]
   },
@@ -8478,7 +8478,7 @@
     "preferred_prefix": "OPMI",
     "uri_format": "http://purl.obolibrary.org/obo/OPMI_$1",
     "prefix": "opmi",
-    "all_prefixes": [
+    "synonyms": [
       "opmi"
     ]
   },
@@ -8489,7 +8489,7 @@
     "preferred_prefix": "orcid",
     "uri_format": "https://orcid.org/$1",
     "prefix": "orcid",
-    "all_prefixes": [
+    "synonyms": [
       "orcid"
     ]
   },
@@ -8500,7 +8500,7 @@
     "preferred_prefix": "ordb",
     "uri_format": "http://senselab.med.yale.edu/ORDB/Data/$1",
     "prefix": "ordb",
-    "all_prefixes": [
+    "synonyms": [
       "ordb"
     ]
   },
@@ -8511,7 +8511,7 @@
     "preferred_prefix": "oridb.sacch",
     "uri_format": "http://cerevisiae.oridb.org/details.php?id=$1",
     "prefix": "oridb.sacch",
-    "all_prefixes": [
+    "synonyms": [
       "oridb.sacch"
     ]
   },
@@ -8522,7 +8522,7 @@
     "preferred_prefix": "oridb.schizo",
     "uri_format": "http://pombe.oridb.org/details.php?id=$1",
     "prefix": "oridb.schizo",
-    "all_prefixes": [
+    "synonyms": [
       "oridb.schizo"
     ]
   },
@@ -8532,7 +8532,7 @@
     "preferred_prefix": "ORNASEQ",
     "uri_format": "http://purl.obolibrary.org/obo/ORNASEQ_$1",
     "prefix": "ornaseq",
-    "all_prefixes": [
+    "synonyms": [
       "ornaseq"
     ]
   },
@@ -8543,7 +8543,7 @@
     "preferred_prefix": "orphanet",
     "uri_format": "http://www.orpha.net/consor/cgi-bin/OC_Exp.php?Lng=EN&Expert=$1",
     "prefix": "orphanet",
-    "all_prefixes": [
+    "synonyms": [
       "orphanet"
     ]
   },
@@ -8554,7 +8554,7 @@
     "preferred_prefix": "orphanet.ordo",
     "uri_format": "http://www.orpha.net/ORDO/Orphanet_$1",
     "prefix": "orphanet.ordo",
-    "all_prefixes": [
+    "synonyms": [
       "ordo",
       "orphanet.ordo"
     ]
@@ -8566,7 +8566,7 @@
     "preferred_prefix": "orthodb",
     "uri_format": "http://cegg.unige.ch/orthodb/results?searchtext=$1",
     "prefix": "orthodb",
-    "all_prefixes": [
+    "synonyms": [
       "orthodb"
     ]
   },
@@ -8577,7 +8577,7 @@
     "preferred_prefix": "oryzabase.gene",
     "uri_format": "http://www.shigen.nig.ac.jp/rice/oryzabaseV4/gene/detail/$1",
     "prefix": "oryzabase.gene",
-    "all_prefixes": [
+    "synonyms": [
       "oryzabase.gene"
     ]
   },
@@ -8588,7 +8588,7 @@
     "preferred_prefix": "oryzabase.mutant",
     "uri_format": "http://www.shigen.nig.ac.jp/rice/oryzabaseV4/strain/inducedMutationLine/detail/$1",
     "prefix": "oryzabase.mutant",
-    "all_prefixes": [
+    "synonyms": [
       "oryzabase.mutant"
     ]
   },
@@ -8599,7 +8599,7 @@
     "preferred_prefix": "oryzabase.reference",
     "uri_format": "https://shigen.nig.ac.jp/rice/oryzabase/reference/detail/$1",
     "prefix": "oryzabase.reference",
-    "all_prefixes": [
+    "synonyms": [
       "oryzabase.reference"
     ]
   },
@@ -8610,7 +8610,7 @@
     "preferred_prefix": "oryzabase.stage",
     "uri_format": "http://www.shigen.nig.ac.jp/rice/oryzabaseV4/devstageineachorgan/detail/$1",
     "prefix": "oryzabase.stage",
-    "all_prefixes": [
+    "synonyms": [
       "oryzabase.stage"
     ]
   },
@@ -8621,7 +8621,7 @@
     "preferred_prefix": "oryzabase.strain",
     "uri_format": "http://www.shigen.nig.ac.jp/rice/oryzabaseV4/strain/wildCore/detail/$1",
     "prefix": "oryzabase.strain",
-    "all_prefixes": [
+    "synonyms": [
       "oryzabase.strain"
     ]
   },
@@ -8632,7 +8632,7 @@
     "preferred_prefix": "otl",
     "uri_format": "http://oryzatagline.cirad.fr/cgi-bin/general_mutant.pl?line=$1",
     "prefix": "otl",
-    "all_prefixes": [
+    "synonyms": [
       "otl"
     ]
   },
@@ -8642,7 +8642,7 @@
     "preferred_prefix": "OVAE",
     "uri_format": "http://purl.obolibrary.org/obo/OVAE_$1",
     "prefix": "ovae",
-    "all_prefixes": [
+    "synonyms": [
       "ovae"
     ]
   },
@@ -8652,7 +8652,7 @@
     "preferred_prefix": "owl",
     "uri_format": "http://www.w3.org/2002/07/owl#$1",
     "prefix": "owl",
-    "all_prefixes": [
+    "synonyms": [
       "owl"
     ]
   },
@@ -8663,7 +8663,7 @@
     "preferred_prefix": "p3db.protein",
     "uri_format": "http://www.p3db.org/protein.php?id=$1&amp;ref=0",
     "prefix": "p3db.protein",
-    "all_prefixes": [
+    "synonyms": [
       "p3db.protein"
     ]
   },
@@ -8674,7 +8674,7 @@
     "preferred_prefix": "p3db.site",
     "uri_format": "http://www.p3db.org/phosphosite.php?id=$1&ref=0",
     "prefix": "p3db.site",
-    "all_prefixes": [
+    "synonyms": [
       "p3db.site"
     ]
   },
@@ -8685,7 +8685,7 @@
     "preferred_prefix": "paleodb",
     "uri_format": "http://fossilworks.org/?a=taxonInfo&taxon_no=$1",
     "prefix": "paleodb",
-    "all_prefixes": [
+    "synonyms": [
       "paleodb"
     ]
   },
@@ -8695,7 +8695,7 @@
     "preferred_prefix": "panorama",
     "uri_format": "https://panoramaweb.org/$1.url",
     "prefix": "panorama",
-    "all_prefixes": [
+    "synonyms": [
       "panorama"
     ]
   },
@@ -8706,7 +8706,7 @@
     "preferred_prefix": "panther.family",
     "uri_format": "http://www.pantherdb.org/panther/family.do?clsAccession=$1",
     "prefix": "panther.family",
-    "all_prefixes": [
+    "synonyms": [
       "panther.family"
     ]
   },
@@ -8717,7 +8717,7 @@
     "preferred_prefix": "panther.node",
     "uri_format": "http://www.pantree.org/node/annotationNode.jsp?id=$1",
     "prefix": "panther.node",
-    "all_prefixes": [
+    "synonyms": [
       "panther.node"
     ]
   },
@@ -8728,7 +8728,7 @@
     "preferred_prefix": "panther.pathway",
     "uri_format": "http://www.pantherdb.org/pathway/pathwayDiagram.jsp?catAccession=$1",
     "prefix": "panther.pathway",
-    "all_prefixes": [
+    "synonyms": [
       "panther.pathway"
     ]
   },
@@ -8739,7 +8739,7 @@
     "preferred_prefix": "panther.pthcmp",
     "uri_format": "http://www.pantherdb.org/pathway/pathCatDetail.do?clsAccession=$1",
     "prefix": "panther.pthcmp",
-    "all_prefixes": [
+    "synonyms": [
       "panther.pthcmp"
     ]
   },
@@ -8749,7 +8749,7 @@
     "preferred_prefix": "PAO",
     "uri_format": "http://purl.obolibrary.org/obo/PAO_$1",
     "prefix": "pao",
-    "all_prefixes": [
+    "synonyms": [
       "pao"
     ]
   },
@@ -8761,7 +8761,7 @@
     "preferred_prefix": "pass2",
     "uri_format": "http://caps.ncbs.res.in/cgi-bin/pass2//show_sf.py?sf_id=$1",
     "prefix": "pass2",
-    "all_prefixes": [
+    "synonyms": [
       "pass2"
     ]
   },
@@ -8772,7 +8772,7 @@
     "preferred_prefix": "pathbank",
     "uri_format": "https://pathbank.org/view/$1",
     "prefix": "pathbank",
-    "all_prefixes": [
+    "synonyms": [
       "pathbank"
     ]
   },
@@ -8783,7 +8783,7 @@
     "preferred_prefix": "pathwaycommons",
     "uri_format": "http://www.pathwaycommons.org/pc/record2.do?id=$1",
     "prefix": "pathwaycommons",
-    "all_prefixes": [
+    "synonyms": [
       "pathwaycommons"
     ]
   },
@@ -8794,7 +8794,7 @@
     "preferred_prefix": "PATO",
     "uri_format": "https://www.ebi.ac.uk/ols/ontologies/pato/terms?obo_id=PATO:$1",
     "prefix": "pato",
-    "all_prefixes": [
+    "synonyms": [
       "pato"
     ]
   },
@@ -8805,7 +8805,7 @@
     "preferred_prefix": "pav",
     "uri_format": "https://pav-ontology.github.io/pav/index.html#http://purl.org/pav/$1",
     "prefix": "pav",
-    "all_prefixes": [
+    "synonyms": [
       "pav"
     ]
   },
@@ -8816,7 +8816,7 @@
     "preferred_prefix": "paxdb.organism",
     "uri_format": "http://pax-db.org/#!species/$1",
     "prefix": "paxdb.organism",
-    "all_prefixes": [
+    "synonyms": [
       "paxdb.organism"
     ]
   },
@@ -8827,7 +8827,7 @@
     "preferred_prefix": "paxdb.protein",
     "uri_format": "http://pax-db.org/#!protein/$1",
     "prefix": "paxdb.protein",
-    "all_prefixes": [
+    "synonyms": [
       "paxdb.protein"
     ]
   },
@@ -8838,7 +8838,7 @@
     "preferred_prefix": "pazar",
     "uri_format": "http://www.pazar.info/cgi-bin/tf_search.cgi?geneID=$1",
     "prefix": "pazar",
-    "all_prefixes": [
+    "synonyms": [
       "pazar"
     ]
   },
@@ -8849,7 +8849,7 @@
     "preferred_prefix": "PCO",
     "uri_format": "http://purl.obolibrary.org/obo/PCO_$1",
     "prefix": "pco",
-    "all_prefixes": [
+    "synonyms": [
       "pco"
     ]
   },
@@ -8859,7 +8859,7 @@
     "preferred_prefix": "PD_ST",
     "uri_format": "http://purl.obolibrary.org/obo/PD_ST_$1",
     "prefix": "pd_st",
-    "all_prefixes": [
+    "synonyms": [
       "pd_st"
     ]
   },
@@ -8870,7 +8870,7 @@
     "preferred_prefix": "pdb",
     "uri_format": "https://www.rcsb.org/structure/$1",
     "prefix": "pdb",
-    "all_prefixes": [
+    "synonyms": [
       "pdb",
       "pdbe",
       "wwpdb"
@@ -8883,7 +8883,7 @@
     "preferred_prefix": "pdb-ccd",
     "uri_format": "https://www.ebi.ac.uk/pdbe-srv/pdbechem/chemicalCompound/show/$1",
     "prefix": "pdb-ccd",
-    "all_prefixes": [
+    "synonyms": [
       "pdb-ccd",
       "pdbechem"
     ]
@@ -8895,7 +8895,7 @@
     "preferred_prefix": "pdb.ligand",
     "uri_format": "http://www.rcsb.org/pdb/ligand/ligandsummary.do?hetId=$1",
     "prefix": "pdb.ligand",
-    "all_prefixes": [
+    "synonyms": [
       "pdb.ligand",
       "pdb_chem_id"
     ]
@@ -8906,7 +8906,7 @@
     "preferred_prefix": "PDRO",
     "uri_format": "http://purl.obolibrary.org/obo/PDRO_$1",
     "prefix": "pdro",
-    "all_prefixes": [
+    "synonyms": [
       "pdro"
     ]
   },
@@ -8917,7 +8917,7 @@
     "preferred_prefix": "PdumDv",
     "uri_format": "http://purl.obolibrary.org/obo/PDUMDV_$1",
     "prefix": "pdumdv",
-    "all_prefixes": [
+    "synonyms": [
       "pdumdv"
     ]
   },
@@ -8929,7 +8929,7 @@
     "preferred_prefix": "PECO",
     "uri_format": "http://archive.gramene.org/db/ontology/search?query=EO:$1",
     "prefix": "peco",
-    "all_prefixes": [
+    "synonyms": [
       "eo",
       "peco"
     ]
@@ -8941,7 +8941,7 @@
     "preferred_prefix": "ped",
     "uri_format": "https://proteinensemble.org/$1",
     "prefix": "ped",
-    "all_prefixes": [
+    "synonyms": [
       "ped"
     ]
   },
@@ -8952,7 +8952,7 @@
     "preferred_prefix": "ped.ensemble",
     "uri_format": "https://proteinensemble.org/$1",
     "prefix": "ped.ensemble",
-    "all_prefixes": [
+    "synonyms": [
       "ped.ensemble"
     ]
   },
@@ -8963,7 +8963,7 @@
     "preferred_prefix": "peptideatlas",
     "uri_format": "https://db.systemsbiology.net/sbeams/cgi/PeptideAtlas/Summarize_Peptide?query=QUERY&searchForThis=$1",
     "prefix": "peptideatlas",
-    "all_prefixes": [
+    "synonyms": [
       "peptideatlas"
     ]
   },
@@ -8974,7 +8974,7 @@
     "preferred_prefix": "peptideatlas.dataset",
     "uri_format": "http://www.peptideatlas.org/PASS/$1",
     "prefix": "peptideatlas.dataset",
-    "all_prefixes": [
+    "synonyms": [
       "peptideatlas.dataset"
     ]
   },
@@ -8985,7 +8985,7 @@
     "preferred_prefix": "peroxibase",
     "uri_format": "http://peroxibase.toulouse.inra.fr/browse/process/view_perox.php?id=$1",
     "prefix": "peroxibase",
-    "all_prefixes": [
+    "synonyms": [
       "peroxibase"
     ]
   },
@@ -8995,7 +8995,7 @@
     "preferred_prefix": "pesticides",
     "uri_format": "http://www.alanwood.net/pesticides/$1.html",
     "prefix": "pesticides",
-    "all_prefixes": [
+    "synonyms": [
       "pesticides"
     ]
   },
@@ -9006,7 +9006,7 @@
     "preferred_prefix": "pfam",
     "uri_format": "https://pfam.xfam.org/family/$1",
     "prefix": "pfam",
-    "all_prefixes": [
+    "synonyms": [
       "pf",
       "pfam"
     ]
@@ -9018,7 +9018,7 @@
     "preferred_prefix": "pfam.clan",
     "uri_format": "https://pfam.xfam.org/clan/$1",
     "prefix": "pfam.clan",
-    "all_prefixes": [
+    "synonyms": [
       "pfam.clan"
     ]
   },
@@ -9029,7 +9029,7 @@
     "preferred_prefix": "pfr",
     "uri_format": "http://repository.topdownproteomics.org/proteoforms/$1",
     "prefix": "pfr",
-    "all_prefixes": [
+    "synonyms": [
       "pfr",
       "tdr"
     ]
@@ -9040,7 +9040,7 @@
     "preferred_prefix": "PGDSO",
     "uri_format": "http://purl.obolibrary.org/obo/PGDSO_$1",
     "prefix": "pgdso",
-    "all_prefixes": [
+    "synonyms": [
       "pgdso"
     ]
   },
@@ -9051,7 +9051,7 @@
     "preferred_prefix": "pgs",
     "uri_format": "https://www.pgscatalog.org/pgs/$1",
     "prefix": "pgs",
-    "all_prefixes": [
+    "synonyms": [
       "pgs"
     ]
   },
@@ -9062,7 +9062,7 @@
     "preferred_prefix": "pgx",
     "uri_format": "https://progenetix.org/services/ids/$1",
     "prefix": "pgx",
-    "all_prefixes": [
+    "synonyms": [
       "pgx"
     ]
   },
@@ -9072,7 +9072,7 @@
     "preferred_prefix": "pharmacodb.cell",
     "uri_format": "https://pharmacodb.ca/cell_lines/$1",
     "prefix": "pharmacodb.cell",
-    "all_prefixes": [
+    "synonyms": [
       "pharmacodb.cell"
     ]
   },
@@ -9082,7 +9082,7 @@
     "preferred_prefix": "pharmacodb.dataset",
     "uri_format": "https://pharmacodb.ca/datasets/$1",
     "prefix": "pharmacodb.dataset",
-    "all_prefixes": [
+    "synonyms": [
       "pharmacodb.dataset"
     ]
   },
@@ -9092,7 +9092,7 @@
     "preferred_prefix": "pharmacodb.tissue",
     "uri_format": "https://pharmacodb.ca/tissues/$1",
     "prefix": "pharmacodb.tissue",
-    "all_prefixes": [
+    "synonyms": [
       "pharmacodb.tissue"
     ]
   },
@@ -9103,7 +9103,7 @@
     "preferred_prefix": "pharmgkb.disease",
     "uri_format": "http://www.pharmgkb.org/disease/$1",
     "prefix": "pharmgkb.disease",
-    "all_prefixes": [
+    "synonyms": [
       "pharmgkb.disease"
     ]
   },
@@ -9114,7 +9114,7 @@
     "preferred_prefix": "pharmgkb.drug",
     "uri_format": "http://www.pharmgkb.org/drug/$1",
     "prefix": "pharmgkb.drug",
-    "all_prefixes": [
+    "synonyms": [
       "pharmgkb.drug"
     ]
   },
@@ -9125,7 +9125,7 @@
     "preferred_prefix": "pharmgkb.gene",
     "uri_format": "http://www.pharmgkb.org/gene/$1",
     "prefix": "pharmgkb.gene",
-    "all_prefixes": [
+    "synonyms": [
       "pharmgkb.gene"
     ]
   },
@@ -9136,7 +9136,7 @@
     "preferred_prefix": "pharmgkb.pathways",
     "uri_format": "http://www.pharmgkb.org/pathway/$1",
     "prefix": "pharmgkb.pathways",
-    "all_prefixes": [
+    "synonyms": [
       "pharmgkb.pathways"
     ]
   },
@@ -9147,7 +9147,7 @@
     "preferred_prefix": "phenolexplorer",
     "uri_format": "http://phenol-explorer.eu/foods/$1",
     "prefix": "phenolexplorer",
-    "all_prefixes": [
+    "synonyms": [
       "phenolexplorer"
     ]
   },
@@ -9158,7 +9158,7 @@
     "preferred_prefix": "PHIPO",
     "uri_format": "http://purl.obolibrary.org/obo/PHIPO_$1",
     "prefix": "phipo",
-    "all_prefixes": [
+    "synonyms": [
       "phipo"
     ]
   },
@@ -9169,7 +9169,7 @@
     "preferred_prefix": "phosphopoint.kinase",
     "uri_format": "http://kinase.bioinformatics.tw/showall.jsp?type=Kinase&info=Gene&name=$1&drawing=0&sorting=0&kinome=1",
     "prefix": "phosphopoint.kinase",
-    "all_prefixes": [
+    "synonyms": [
       "phosphopoint.kinase"
     ]
   },
@@ -9180,7 +9180,7 @@
     "preferred_prefix": "phosphopoint.protein",
     "uri_format": "http://kinase.bioinformatics.tw/showall.jsp?type=PhosphoProtein&info=Gene&name=$1&drawing=0&sorting=0&kinome=0",
     "prefix": "phosphopoint.protein",
-    "all_prefixes": [
+    "synonyms": [
       "phosphopoint.protein"
     ]
   },
@@ -9191,7 +9191,7 @@
     "preferred_prefix": "phosphosite.protein",
     "uri_format": "http://www.phosphosite.org/proteinAction.do?id=$1",
     "prefix": "phosphosite.protein",
-    "all_prefixes": [
+    "synonyms": [
       "phosphosite.protein"
     ]
   },
@@ -9202,7 +9202,7 @@
     "preferred_prefix": "phosphosite.residue",
     "uri_format": "http://www.phosphosite.org/siteAction.do?id=$1",
     "prefix": "phosphosite.residue",
-    "all_prefixes": [
+    "synonyms": [
       "phosphosite.residue"
     ]
   },
@@ -9213,7 +9213,7 @@
     "preferred_prefix": "phylomedb",
     "uri_format": "http://phylomedb.org/?seqid=$1",
     "prefix": "phylomedb",
-    "all_prefixes": [
+    "synonyms": [
       "phylomedb"
     ]
   },
@@ -9224,7 +9224,7 @@
     "preferred_prefix": "phytozome.locus",
     "uri_format": "http://www.phytozome.net/genePage.php?crown&method=0&search=1&detail=1&searchText=locusname:$1",
     "prefix": "phytozome.locus",
-    "all_prefixes": [
+    "synonyms": [
       "phytozome.locus"
     ]
   },
@@ -9235,7 +9235,7 @@
     "preferred_prefix": "pid.pathway",
     "uri_format": "http://pid.nci.nih.gov/search/pathway_landing.shtml?what=graphic&jpg=on&pathway_id=$1",
     "prefix": "pid.pathway",
-    "all_prefixes": [
+    "synonyms": [
       "pid",
       "pid.pathway"
     ]
@@ -9247,7 +9247,7 @@
     "preferred_prefix": "pigqtldb",
     "uri_format": "https://www.animalgenome.org/QTLdb/q?id=QTL_ID:$1",
     "prefix": "pigqtldb",
-    "all_prefixes": [
+    "synonyms": [
       "pigqtldb"
     ]
   },
@@ -9258,7 +9258,7 @@
     "preferred_prefix": "pina",
     "uri_format": "http://cbg.garvan.unsw.edu.au/pina/interactome.oneP.do?ac=$1&showExtend=null",
     "prefix": "pina",
-    "all_prefixes": [
+    "synonyms": [
       "pina"
     ]
   },
@@ -9269,7 +9269,7 @@
     "preferred_prefix": "piroplasma",
     "uri_format": "http://piroplasmadb.org/piro/showRecord.do?name=GeneRecordClasses.GeneRecordClass&source_id=$1",
     "prefix": "piroplasma",
-    "all_prefixes": [
+    "synonyms": [
       "piroplasma"
     ]
   },
@@ -9280,7 +9280,7 @@
     "preferred_prefix": "pirsf",
     "uri_format": "https://pir.georgetown.edu/cgi-bin/ipcSF?id=$1",
     "prefix": "pirsf",
-    "all_prefixes": [
+    "synonyms": [
       "pirsf"
     ]
   },
@@ -9291,7 +9291,7 @@
     "preferred_prefix": "pkdb",
     "uri_format": "https://pk-db.com/data/$1",
     "prefix": "pkdb",
-    "all_prefixes": [
+    "synonyms": [
       "pkdb"
     ]
   },
@@ -9302,7 +9302,7 @@
     "preferred_prefix": "PLANA",
     "uri_format": "http://purl.obolibrary.org/obo/PLANA_$1",
     "prefix": "plana",
-    "all_prefixes": [
+    "synonyms": [
       "plana"
     ]
   },
@@ -9313,7 +9313,7 @@
     "preferred_prefix": "PLANP",
     "uri_format": "http://purl.obolibrary.org/obo/PLANP_$1",
     "prefix": "planp",
-    "all_prefixes": [
+    "synonyms": [
       "planp"
     ]
   },
@@ -9324,7 +9324,7 @@
     "preferred_prefix": "planttfdb",
     "uri_format": "http://planttfdb.cbi.pku.edu.cn/tf.php?uid=$1",
     "prefix": "planttfdb",
-    "all_prefixes": [
+    "synonyms": [
       "planttfdb"
     ]
   },
@@ -9335,7 +9335,7 @@
     "preferred_prefix": "plasmodb",
     "uri_format": "http://plasmodb.org/plasmo/showRecord.do?name=GeneRecordClasses.GeneRecordClass&source_id=$1",
     "prefix": "plasmodb",
-    "all_prefixes": [
+    "synonyms": [
       "apidb_plasmodb",
       "plasmodb"
     ]
@@ -9346,7 +9346,7 @@
     "preferred_prefix": "PLO",
     "uri_format": "http://purl.obolibrary.org/obo/PLO_$1",
     "prefix": "plo",
-    "all_prefixes": [
+    "synonyms": [
       "plo"
     ]
   },
@@ -9357,7 +9357,7 @@
     "preferred_prefix": "pmap.cutdb",
     "uri_format": "http://cutdb.burnham.org/relation/show/$1",
     "prefix": "pmap.cutdb",
-    "all_prefixes": [
+    "synonyms": [
       "pmap.cutdb"
     ]
   },
@@ -9368,7 +9368,7 @@
     "preferred_prefix": "pmap.substratedb",
     "uri_format": "http://substrate.burnham.org/protein/annotation/$1/html",
     "prefix": "pmap.substratedb",
-    "all_prefixes": [
+    "synonyms": [
       "pmap.substratedb"
     ]
   },
@@ -9379,7 +9379,7 @@
     "preferred_prefix": "pmc",
     "uri_format": "http://europepmc.org/articles/$1",
     "prefix": "pmc",
-    "all_prefixes": [
+    "synonyms": [
       "pmc",
       "pmcid"
     ]
@@ -9391,7 +9391,7 @@
     "preferred_prefix": "pmdb",
     "uri_format": "https://bioinformatics.cineca.it/PMDB/user//search.php?idsearch=$1",
     "prefix": "pmdb",
-    "all_prefixes": [
+    "synonyms": [
       "pmdb"
     ]
   },
@@ -9402,7 +9402,7 @@
     "preferred_prefix": "pmp",
     "uri_format": "http://www.proteinmodelportal.org/query/uniprot/$1",
     "prefix": "pmp",
-    "all_prefixes": [
+    "synonyms": [
       "pmp"
     ]
   },
@@ -9413,7 +9413,7 @@
     "preferred_prefix": "pmr",
     "uri_format": "https://models.physiomeproject.org/exposure/$1",
     "prefix": "pmr",
-    "all_prefixes": [
+    "synonyms": [
       "pmr"
     ]
   },
@@ -9424,7 +9424,7 @@
     "preferred_prefix": "PO",
     "uri_format": "http://www.plantontology.org/amigo/go.cgi?view=details&query=PO:$1",
     "prefix": "po",
-    "all_prefixes": [
+    "synonyms": [
       "po"
     ]
   },
@@ -9435,7 +9435,7 @@
     "preferred_prefix": "pocketome",
     "uri_format": "http://www.pocketome.org/files/$1.html",
     "prefix": "pocketome",
-    "all_prefixes": [
+    "synonyms": [
       "pocketome"
     ]
   },
@@ -9446,7 +9446,7 @@
     "preferred_prefix": "polbase",
     "uri_format": "https://polbase.neb.com/polymerases/$1#sequences",
     "prefix": "polbase",
-    "all_prefixes": [
+    "synonyms": [
       "polbase"
     ]
   },
@@ -9457,7 +9457,7 @@
     "preferred_prefix": "pombase",
     "uri_format": "http://www.pombase.org/spombe/result/$1",
     "prefix": "pombase",
-    "all_prefixes": [
+    "synonyms": [
       "pombase"
     ]
   },
@@ -9468,7 +9468,7 @@
     "preferred_prefix": "PORO",
     "uri_format": "http://purl.obolibrary.org/obo/PORO_$1",
     "prefix": "poro",
-    "all_prefixes": [
+    "synonyms": [
       "poro"
     ]
   },
@@ -9478,7 +9478,7 @@
     "preferred_prefix": "ppdb",
     "uri_format": "https://sitem.herts.ac.uk/aeru/ppdb/en/Reports/$1.htm",
     "prefix": "ppdb",
-    "all_prefixes": [
+    "synonyms": [
       "ppdb"
     ]
   },
@@ -9488,7 +9488,7 @@
     "preferred_prefix": "PPO",
     "uri_format": "http://purl.obolibrary.org/obo/PPO_$1",
     "prefix": "ppo",
-    "all_prefixes": [
+    "synonyms": [
       "ppo"
     ]
   },
@@ -9498,7 +9498,7 @@
     "preferred_prefix": "ppr",
     "uri_format": "https://europepmc.org/article/ppr/$1",
     "prefix": "ppr",
-    "all_prefixes": [
+    "synonyms": [
       "ppr"
     ]
   },
@@ -9509,7 +9509,7 @@
     "preferred_prefix": "PR",
     "uri_format": "https://proconsortium.org/app/entry/PR:$1",
     "prefix": "pr",
-    "all_prefixes": [
+    "synonyms": [
       "pr",
       "pro"
     ]
@@ -9521,7 +9521,7 @@
     "preferred_prefix": "pride",
     "uri_format": "https://www.ebi.ac.uk/pride/archive/assays/$1",
     "prefix": "pride",
-    "all_prefixes": [
+    "synonyms": [
       "pride"
     ]
   },
@@ -9532,7 +9532,7 @@
     "preferred_prefix": "pride.project",
     "uri_format": "https://www.ebi.ac.uk/pride/archive/projects/$1",
     "prefix": "pride.project",
-    "all_prefixes": [
+    "synonyms": [
       "pride.project"
     ]
   },
@@ -9543,7 +9543,7 @@
     "preferred_prefix": "prints",
     "uri_format": "http://www.bioinf.manchester.ac.uk/cgi-bin/dbbrowser/sprint/searchprintss.cgi?prints_accn=$1&display_opts=Prints&category=None&queryform=false&regexpr=off",
     "prefix": "prints",
-    "all_prefixes": [
+    "synonyms": [
       "prints"
     ]
   },
@@ -9554,7 +9554,7 @@
     "preferred_prefix": "probonto",
     "uri_format": "https://www.ebi.ac.uk/ols/ontologies/probonto/terms?short_form=$1",
     "prefix": "probonto",
-    "all_prefixes": [
+    "synonyms": [
       "probonto"
     ]
   },
@@ -9565,7 +9565,7 @@
     "preferred_prefix": "prodom",
     "uri_format": "http://prodom.prabi.fr/prodom/current/cgi-bin/request.pl?question=DBEN&query=$1",
     "prefix": "prodom",
-    "all_prefixes": [
+    "synonyms": [
       "prodom"
     ]
   },
@@ -9576,7 +9576,7 @@
     "preferred_prefix": "proglyc",
     "uri_format": "http://www.proglycprot.org/detail.aspx?ProId=$1",
     "prefix": "proglyc",
-    "all_prefixes": [
+    "synonyms": [
       "proglyc"
     ]
   },
@@ -9586,7 +9586,7 @@
     "preferred_prefix": "PROPREO",
     "uri_format": "http://purl.obolibrary.org/obo/PROPREO_$1",
     "prefix": "propreo",
-    "all_prefixes": [
+    "synonyms": [
       "propreo"
     ]
   },
@@ -9597,7 +9597,7 @@
     "preferred_prefix": "prosite",
     "uri_format": "https://prosite.expasy.org/$1",
     "prefix": "prosite",
-    "all_prefixes": [
+    "synonyms": [
       "prosite"
     ]
   },
@@ -9608,7 +9608,7 @@
     "preferred_prefix": "protclustdb",
     "uri_format": "https://www.ncbi.nlm.nih.gov/sites/entrez?Db=proteinclusters&Cmd=DetailsSearch&Term=$1",
     "prefix": "protclustdb",
-    "all_prefixes": [
+    "synonyms": [
       "protclustdb"
     ]
   },
@@ -9619,7 +9619,7 @@
     "preferred_prefix": "proteomicsdb.peptide",
     "uri_format": "https://www.proteomicsdb.org/#human/proteinDetails/$1",
     "prefix": "proteomicsdb.peptide",
-    "all_prefixes": [
+    "synonyms": [
       "proteomicsdb.peptide"
     ]
   },
@@ -9630,7 +9630,7 @@
     "preferred_prefix": "proteomicsdb.protein",
     "uri_format": "https://www.proteomicsdb.org/#human/proteinDetails/$1/summary",
     "prefix": "proteomicsdb.protein",
-    "all_prefixes": [
+    "synonyms": [
       "proteomicsdb.protein"
     ]
   },
@@ -9641,7 +9641,7 @@
     "preferred_prefix": "protonet.cluster",
     "uri_format": "http://www.protonet.cs.huji.ac.il/requested/cluster_card.php?cluster=$1",
     "prefix": "protonet.cluster",
-    "all_prefixes": [
+    "synonyms": [
       "protonet.cluster"
     ]
   },
@@ -9652,7 +9652,7 @@
     "preferred_prefix": "protonet.proteincard",
     "uri_format": "http://www.protonet.cs.huji.ac.il/requested/protein_card.php?protein_id=$1",
     "prefix": "protonet.proteincard",
-    "all_prefixes": [
+    "synonyms": [
       "protonet.proteincard"
     ]
   },
@@ -9662,7 +9662,7 @@
     "preferred_prefix": "prov",
     "uri_format": "https://www.w3.org/ns/prov#$1",
     "prefix": "prov",
-    "all_prefixes": [
+    "synonyms": [
       "prov"
     ]
   },
@@ -9673,7 +9673,7 @@
     "preferred_prefix": "pscdb",
     "uri_format": "http://idp1.force.cs.is.nagoya-u.ac.jp/pscdb/$1.html",
     "prefix": "pscdb",
-    "all_prefixes": [
+    "synonyms": [
       "pscdb"
     ]
   },
@@ -9683,7 +9683,7 @@
     "preferred_prefix": "PSDO",
     "uri_format": "http://purl.obolibrary.org/obo/PSDO_$1",
     "prefix": "psdo",
-    "all_prefixes": [
+    "synonyms": [
       "psdo"
     ]
   },
@@ -9694,7 +9694,7 @@
     "preferred_prefix": "pseudomonas",
     "uri_format": "http://www.pseudomonas.com/feature/show/?locus_tag=$1",
     "prefix": "pseudomonas",
-    "all_prefixes": [
+    "synonyms": [
       "pseudomonas"
     ]
   },
@@ -9705,7 +9705,7 @@
     "preferred_prefix": "psipar",
     "uri_format": "https://www.ebi.ac.uk/ontology-lookup/?termId=$1",
     "prefix": "psipar",
-    "all_prefixes": [
+    "synonyms": [
       "psipar"
     ]
   },
@@ -9715,7 +9715,7 @@
     "preferred_prefix": "PSO",
     "uri_format": "http://purl.obolibrary.org/obo/PSO_$1",
     "prefix": "pso",
-    "all_prefixes": [
+    "synonyms": [
       "pso"
     ]
   },
@@ -9726,7 +9726,7 @@
     "preferred_prefix": "pubchem.bioassay",
     "uri_format": "https://pubchem.ncbi.nlm.nih.gov/bioassay/$1",
     "prefix": "pubchem.bioassay",
-    "all_prefixes": [
+    "synonyms": [
       "pubchem.bioassay"
     ]
   },
@@ -9737,7 +9737,7 @@
     "preferred_prefix": "pubchem.compound",
     "uri_format": "https://pubchem.ncbi.nlm.nih.gov/compound/$1",
     "prefix": "pubchem.compound",
-    "all_prefixes": [
+    "synonyms": [
       "cid",
       "dsstox_cid",
       "pubchem",
@@ -9754,7 +9754,7 @@
     "preferred_prefix": "pubchem.substance",
     "uri_format": "https://pubchem.ncbi.nlm.nih.gov/substance/$1",
     "prefix": "pubchem.substance",
-    "all_prefixes": [
+    "synonyms": [
       "dsstox_generic_sid",
       "pubchem.substance"
     ]
@@ -9765,7 +9765,7 @@
     "preferred_prefix": "publons.researcher",
     "uri_format": "https://publons.com/researcher/$1",
     "prefix": "publons.researcher",
-    "all_prefixes": [
+    "synonyms": [
       "publons.researcher"
     ]
   },
@@ -9776,7 +9776,7 @@
     "preferred_prefix": "pubmed",
     "uri_format": "https://www.ncbi.nlm.nih.gov/pubmed/$1",
     "prefix": "pubmed",
-    "all_prefixes": [
+    "synonyms": [
       "medline",
       "pmid",
       "pubmed"
@@ -9789,7 +9789,7 @@
     "preferred_prefix": "PW",
     "uri_format": "http://rgd.mcw.edu/rgdweb/ontology/annot.html?acc_id=PW:$1",
     "prefix": "pw",
-    "all_prefixes": [
+    "synonyms": [
       "pw"
     ]
   },
@@ -9800,7 +9800,7 @@
     "preferred_prefix": "px",
     "uri_format": "http://proteomecentral.proteomexchange.org/cgi/GetDataset?ID=$1",
     "prefix": "px",
-    "all_prefixes": [
+    "synonyms": [
       "px"
     ]
   },
@@ -9811,7 +9811,7 @@
     "preferred_prefix": "pypi",
     "uri_format": "https://pypi.org/project/$1",
     "prefix": "pypi",
-    "all_prefixes": [
+    "synonyms": [
       "pypi"
     ]
   },
@@ -9822,7 +9822,7 @@
     "preferred_prefix": "qtldb",
     "uri_format": "https://www.animalgenome.org/QTLdb/q?id=QTL_ID:$1",
     "prefix": "qtldb",
-    "all_prefixes": [
+    "synonyms": [
       "qtldb"
     ]
   },
@@ -9832,7 +9832,7 @@
     "preferred_prefix": "qudt",
     "uri_format": "http://qudt.org/schema/qudt#$1",
     "prefix": "qudt",
-    "all_prefixes": [
+    "synonyms": [
       "qudt"
     ]
   },
@@ -9843,7 +9843,7 @@
     "preferred_prefix": "rapdb.locus",
     "uri_format": "https://rapdb.dna.affrc.go.jp/viewer/gbrowse_details/irgsp1?name=$1",
     "prefix": "rapdb.locus",
-    "all_prefixes": [
+    "synonyms": [
       "rapdb.locus"
     ]
   },
@@ -9854,7 +9854,7 @@
     "preferred_prefix": "rapdb.transcript",
     "uri_format": "https://rapdb.dna.affrc.go.jp/viewer/gene_detail/irgsp1?name=$1",
     "prefix": "rapdb.transcript",
-    "all_prefixes": [
+    "synonyms": [
       "rapdb.transcript"
     ]
   },
@@ -9865,7 +9865,7 @@
     "preferred_prefix": "rbk",
     "uri_format": "https://www.rebuildingakidney.org/id/$1",
     "prefix": "rbk",
-    "all_prefixes": [
+    "synonyms": [
       "rbk"
     ]
   },
@@ -9875,7 +9875,7 @@
     "preferred_prefix": "RBO",
     "uri_format": "http://purl.obolibrary.org/obo/RBO_$1",
     "prefix": "rbo",
-    "all_prefixes": [
+    "synonyms": [
       "rbo"
     ]
   },
@@ -9886,7 +9886,7 @@
     "preferred_prefix": "rcb",
     "uri_format": "https://cellbank.brc.riken.jp/cell_bank/CellInfo/?cellNo=$1",
     "prefix": "rcb",
-    "all_prefixes": [
+    "synonyms": [
       "rcb"
     ]
   },
@@ -9896,7 +9896,7 @@
     "preferred_prefix": "rdf",
     "uri_format": "http://www.w3.org/1999/02/22-rdf-syntax-ns#$1",
     "prefix": "rdf",
-    "all_prefixes": [
+    "synonyms": [
       "rdf"
     ]
   },
@@ -9906,7 +9906,7 @@
     "preferred_prefix": "rdfs",
     "uri_format": "http://www.w3.org/2000/01/rdf-schema#$1",
     "prefix": "rdfs",
-    "all_prefixes": [
+    "synonyms": [
       "rdfs"
     ]
   },
@@ -9917,7 +9917,7 @@
     "preferred_prefix": "re3data",
     "uri_format": "https://www.re3data.org/repository/$1",
     "prefix": "re3data",
-    "all_prefixes": [
+    "synonyms": [
       "re3data"
     ]
   },
@@ -9928,7 +9928,7 @@
     "preferred_prefix": "reactome",
     "uri_format": "https://reactome.org/content/detail/$1",
     "prefix": "reactome",
-    "all_prefixes": [
+    "synonyms": [
       "re",
       "react",
       "reactome"
@@ -9941,7 +9941,7 @@
     "preferred_prefix": "rebase",
     "uri_format": "http://rebase.neb.com/rebase/enz/$1.html",
     "prefix": "rebase",
-    "all_prefixes": [
+    "synonyms": [
       "rebase"
     ]
   },
@@ -9951,7 +9951,7 @@
     "preferred_prefix": "receptome.family",
     "uri_format": "http://www.receptome.org/families/Frameset_family.asp?ProtType=Receptor&FamId=$1",
     "prefix": "receptome.family",
-    "all_prefixes": [
+    "synonyms": [
       "receptome.family"
     ]
   },
@@ -9962,7 +9962,7 @@
     "preferred_prefix": "refseq",
     "uri_format": "https://www.ncbi.nlm.nih.gov/protein/$1",
     "prefix": "refseq",
-    "all_prefixes": [
+    "synonyms": [
       "refseq",
       "refseq_prot"
     ]
@@ -9974,7 +9974,7 @@
     "preferred_prefix": "repeatsdb.protein",
     "uri_format": "https://repeatsdb.org/protein/$1",
     "prefix": "repeatsdb.protein",
-    "all_prefixes": [
+    "synonyms": [
       "repeatsdb.protein"
     ]
   },
@@ -9985,7 +9985,7 @@
     "preferred_prefix": "repeatsdb.structure",
     "uri_format": "https://repeatsdb.org/structure/$1",
     "prefix": "repeatsdb.structure",
-    "all_prefixes": [
+    "synonyms": [
       "repeatsdb.structure"
     ]
   },
@@ -9997,7 +9997,7 @@
     "preferred_prefix": "RESID",
     "uri_format": "http://pir0.georgetown.edu/cgi-bin/resid?id=$1",
     "prefix": "resid",
-    "all_prefixes": [
+    "synonyms": [
       "resid"
     ]
   },
@@ -10007,7 +10007,7 @@
     "preferred_prefix": "REX",
     "uri_format": "http://purl.obolibrary.org/obo/REX_$1",
     "prefix": "rex",
-    "all_prefixes": [
+    "synonyms": [
       "rex"
     ]
   },
@@ -10018,7 +10018,7 @@
     "preferred_prefix": "rfam",
     "uri_format": "https://rfam.xfam.org/family/$1",
     "prefix": "rfam",
-    "all_prefixes": [
+    "synonyms": [
       "rfam"
     ]
   },
@@ -10029,7 +10029,7 @@
     "preferred_prefix": "rgd",
     "uri_format": "http://rgd.mcw.edu/rgdweb/report/gene/main.html?id=$1",
     "prefix": "rgd",
-    "all_prefixes": [
+    "synonyms": [
       "rgd"
     ]
   },
@@ -10040,7 +10040,7 @@
     "preferred_prefix": "rgd.qtl",
     "uri_format": "http://rgd.mcw.edu/rgdweb/report/qtl/main.html?id=$1",
     "prefix": "rgd.qtl",
-    "all_prefixes": [
+    "synonyms": [
       "rgd.qtl"
     ]
   },
@@ -10051,7 +10051,7 @@
     "preferred_prefix": "rgd.strain",
     "uri_format": "http://rgd.mcw.edu/rgdweb/report/strain/main.html?id=$1",
     "prefix": "rgd.strain",
-    "all_prefixes": [
+    "synonyms": [
       "rgd.strain"
     ]
   },
@@ -10062,7 +10062,7 @@
     "preferred_prefix": "rhea",
     "uri_format": "https://www.rhea-db.org/rhea/$1",
     "prefix": "rhea",
-    "all_prefixes": [
+    "synonyms": [
       "rhea"
     ]
   },
@@ -10073,7 +10073,7 @@
     "preferred_prefix": "ricegap",
     "uri_format": "http://rice.plantbiology.msu.edu/cgi-bin/ORF_infopage.cgi?&orf=$1",
     "prefix": "ricegap",
-    "all_prefixes": [
+    "synonyms": [
       "ricegap"
     ]
   },
@@ -10084,7 +10084,7 @@
     "preferred_prefix": "ricenetdb.compound",
     "uri_format": "http://bis.zju.edu.cn/ricenetdb/compounddetails.php?ID=$1",
     "prefix": "ricenetdb.compound",
-    "all_prefixes": [
+    "synonyms": [
       "ricenetdb.compound"
     ]
   },
@@ -10095,7 +10095,7 @@
     "preferred_prefix": "ricenetdb.gene",
     "uri_format": "http://bis.zju.edu.cn/ricenetdb/genedetails.php?ID=$1",
     "prefix": "ricenetdb.gene",
-    "all_prefixes": [
+    "synonyms": [
       "ricenetdb.gene"
     ]
   },
@@ -10106,7 +10106,7 @@
     "preferred_prefix": "ricenetdb.mirna",
     "uri_format": "http://bis.zju.edu.cn/ricenetdb/miRNAdetails.php?ID=$1",
     "prefix": "ricenetdb.mirna",
-    "all_prefixes": [
+    "synonyms": [
       "ricenetdb.mirna"
     ]
   },
@@ -10117,7 +10117,7 @@
     "preferred_prefix": "ricenetdb.protein",
     "uri_format": "http://bis.zju.edu.cn/ricenetdb/proteindetails.php?ID=$1",
     "prefix": "ricenetdb.protein",
-    "all_prefixes": [
+    "synonyms": [
       "ricenetdb.protein"
     ]
   },
@@ -10128,7 +10128,7 @@
     "preferred_prefix": "ricenetdb.reaction",
     "uri_format": "http://bis.zju.edu.cn/ricenetdb/reactiondetails.php?ID=$1",
     "prefix": "ricenetdb.reaction",
-    "all_prefixes": [
+    "synonyms": [
       "ricenetdb.reaction"
     ]
   },
@@ -10139,7 +10139,7 @@
     "preferred_prefix": "rnacentral",
     "uri_format": "https://rnacentral.org/rna/$1",
     "prefix": "rnacentral",
-    "all_prefixes": [
+    "synonyms": [
       "lncrnadb",
       "rnacentral"
     ]
@@ -10150,7 +10150,7 @@
     "preferred_prefix": "rnamod",
     "uri_format": "http://rna.rega.kuleuven.be/cgi-bin/rnamods/rnashow.pl?$1",
     "prefix": "rnamod",
-    "all_prefixes": [
+    "synonyms": [
       "rnamod"
     ]
   },
@@ -10161,7 +10161,7 @@
     "preferred_prefix": "rnamods",
     "uri_format": "http://mods.rna.albany.edu/mods/modifications/view/$1",
     "prefix": "rnamods",
-    "all_prefixes": [
+    "synonyms": [
       "rnamods"
     ]
   },
@@ -10172,7 +10172,7 @@
     "preferred_prefix": "RNAO",
     "uri_format": "http://purl.obolibrary.org/obo/RNAO_$1",
     "prefix": "rnao",
-    "all_prefixes": [
+    "synonyms": [
       "rnao"
     ]
   },
@@ -10183,7 +10183,7 @@
     "preferred_prefix": "RO",
     "uri_format": "http://purl.obolibrary.org/obo/RO_$1",
     "prefix": "ro",
-    "all_prefixes": [
+    "synonyms": [
       "obo_rel",
       "oborel",
       "ro",
@@ -10197,7 +10197,7 @@
     "preferred_prefix": "rouge",
     "uri_format": "https://www.kazusa.or.jp/rouge/gfpage/$1",
     "prefix": "rouge",
-    "all_prefixes": [
+    "synonyms": [
       "rouge"
     ]
   },
@@ -10208,7 +10208,7 @@
     "preferred_prefix": "rrid",
     "uri_format": "https://scicrunch.org/resolver/RRID:$1",
     "prefix": "rrid",
-    "all_prefixes": [
+    "synonyms": [
       "rrid"
     ]
   },
@@ -10219,7 +10219,7 @@
     "preferred_prefix": "RS",
     "uri_format": "http://purl.obolibrary.org/obo/RS_$1",
     "prefix": "rs",
-    "all_prefixes": [
+    "synonyms": [
       "rs"
     ]
   },
@@ -10230,7 +10230,7 @@
     "preferred_prefix": "runbiosimulations",
     "uri_format": "https://run.biosimulations.org/simulations/$1",
     "prefix": "runbiosimulations",
-    "all_prefixes": [
+    "synonyms": [
       "runbiosimulations"
     ]
   },
@@ -10241,7 +10241,7 @@
     "preferred_prefix": "RXNO",
     "uri_format": "http://purl.obolibrary.org/obo/RXNO_$1",
     "prefix": "rxno",
-    "all_prefixes": [
+    "synonyms": [
       "rxno"
     ]
   },
@@ -10252,7 +10252,7 @@
     "preferred_prefix": "rxnorm",
     "uri_format": "https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=$1",
     "prefix": "rxnorm",
-    "all_prefixes": [
+    "synonyms": [
       "rxcui",
       "rxnorm"
     ]
@@ -10264,7 +10264,7 @@
     "preferred_prefix": "sabiork.compound",
     "uri_format": "http://sabiork.h-its.org/newSearch?q=$1",
     "prefix": "sabiork.compound",
-    "all_prefixes": [
+    "synonyms": [
       "sabiork.compound"
     ]
   },
@@ -10275,7 +10275,7 @@
     "preferred_prefix": "sabiork.ec",
     "uri_format": "http://sabiork.h-its.org/newSearch?q=ecnumber:$1",
     "prefix": "sabiork.ec",
-    "all_prefixes": [
+    "synonyms": [
       "sabiork.ec"
     ]
   },
@@ -10286,7 +10286,7 @@
     "preferred_prefix": "sabiork.kineticrecord",
     "uri_format": "http://sabiork.h-its.org/kineticLawEntry.jsp?viewData=true&kinlawid=$1",
     "prefix": "sabiork.kineticrecord",
-    "all_prefixes": [
+    "synonyms": [
       "sabiork.kineticrecord"
     ]
   },
@@ -10297,7 +10297,7 @@
     "preferred_prefix": "sabiork.reaction",
     "uri_format": "http://sabiork.h-its.org/newSearch?q=sabioreactionid:$1",
     "prefix": "sabiork.reaction",
-    "all_prefixes": [
+    "synonyms": [
       "sabiork.reaction"
     ]
   },
@@ -10307,7 +10307,7 @@
     "preferred_prefix": "salk",
     "uri_format": "https://abrc.osu.edu/stocks/number/SALK_$1",
     "prefix": "salk",
-    "all_prefixes": [
+    "synonyms": [
       "salk"
     ]
   },
@@ -10317,7 +10317,7 @@
     "preferred_prefix": "SAO",
     "uri_format": "http://purl.obolibrary.org/obo/SAO_$1",
     "prefix": "sao",
-    "all_prefixes": [
+    "synonyms": [
       "sao"
     ]
   },
@@ -10328,7 +10328,7 @@
     "preferred_prefix": "sasbdb",
     "uri_format": "http://www.sasbdb.org/data/$1",
     "prefix": "sasbdb",
-    "all_prefixes": [
+    "synonyms": [
       "sasbdb"
     ]
   },
@@ -10339,7 +10339,7 @@
     "preferred_prefix": "SBO",
     "uri_format": "https://www.ebi.ac.uk/sbo/main/SBO:$1",
     "prefix": "sbo",
-    "all_prefixes": [
+    "synonyms": [
       "sbo"
     ]
   },
@@ -10349,7 +10349,7 @@
     "preferred_prefix": "SCDO",
     "uri_format": "http://purl.obolibrary.org/obo/SCDO_$1",
     "prefix": "scdo",
-    "all_prefixes": [
+    "synonyms": [
       "scdo"
     ]
   },
@@ -10360,7 +10360,7 @@
     "preferred_prefix": "scop",
     "uri_format": "http://scop.mrc-lmb.cam.ac.uk/scop/search.cgi?sunid=$1",
     "prefix": "scop",
-    "all_prefixes": [
+    "synonyms": [
       "scop"
     ]
   },
@@ -10371,7 +10371,7 @@
     "preferred_prefix": "scretf",
     "uri_format": "http://stormo.wustl.edu/ScerTF/details/$1",
     "prefix": "scretf",
-    "all_prefixes": [
+    "synonyms": [
       "scretf"
     ]
   },
@@ -10382,7 +10382,7 @@
     "preferred_prefix": "sdbs",
     "uri_format": "http://riodb01.ibase.aist.go.jp/sdbs/cgi-bin/cre_frame_disp.cgi?sdbsno=$1",
     "prefix": "sdbs",
-    "all_prefixes": [
+    "synonyms": [
       "sdbs"
     ]
   },
@@ -10393,7 +10393,7 @@
     "preferred_prefix": "sedml.format",
     "uri_format": "https://sed-ml.org/urns.html#format:$1",
     "prefix": "sedml.format",
-    "all_prefixes": [
+    "synonyms": [
       "sedml.format"
     ]
   },
@@ -10404,7 +10404,7 @@
     "preferred_prefix": "sedml.language",
     "uri_format": "https://sed-ml.org/urns.html#language:$1",
     "prefix": "sedml.language",
-    "all_prefixes": [
+    "synonyms": [
       "sedml.language"
     ]
   },
@@ -10415,7 +10415,7 @@
     "preferred_prefix": "seed",
     "uri_format": "http://seed-viewer.theseed.org/seedviewer.cgi?page=Subsystems&subsystem=$1",
     "prefix": "seed",
-    "all_prefixes": [
+    "synonyms": [
       "seed"
     ]
   },
@@ -10426,7 +10426,7 @@
     "preferred_prefix": "seed.compound",
     "uri_format": "http://modelseed.org/biochem/compounds/$1",
     "prefix": "seed.compound",
-    "all_prefixes": [
+    "synonyms": [
       "seed.compound"
     ]
   },
@@ -10437,7 +10437,7 @@
     "preferred_prefix": "seed.reaction",
     "uri_format": "http://modelseed.org/biochem/reactions/$1",
     "prefix": "seed.reaction",
-    "all_prefixes": [
+    "synonyms": [
       "seed.reaction"
     ]
   },
@@ -10447,7 +10447,7 @@
     "preferred_prefix": "SEP",
     "uri_format": "http://purl.obolibrary.org/obo/SEP_$1",
     "prefix": "sep",
-    "all_prefixes": [
+    "synonyms": [
       "sep"
     ]
   },
@@ -10457,7 +10457,7 @@
     "preferred_prefix": "SEPIO",
     "uri_format": "http://purl.obolibrary.org/obo/SEPIO_$1",
     "prefix": "sepio",
-    "all_prefixes": [
+    "synonyms": [
       "sepio"
     ]
   },
@@ -10468,7 +10468,7 @@
     "preferred_prefix": "sgd",
     "uri_format": "https://www.yeastgenome.org/locus/$1",
     "prefix": "sgd",
-    "all_prefixes": [
+    "synonyms": [
       "sgd"
     ]
   },
@@ -10479,7 +10479,7 @@
     "preferred_prefix": "sgd.pathways",
     "uri_format": "http://pathway.yeastgenome.org/YEAST/new-image?type=PATHWAY&object=$1",
     "prefix": "sgd.pathways",
-    "all_prefixes": [
+    "synonyms": [
       "sgd.pathways"
     ]
   },
@@ -10490,7 +10490,7 @@
     "preferred_prefix": "sgn",
     "uri_format": "http://solgenomics.net/phenome/locus_display.pl?locus_id=$1",
     "prefix": "sgn",
-    "all_prefixes": [
+    "synonyms": [
       "sgn"
     ]
   },
@@ -10501,7 +10501,7 @@
     "preferred_prefix": "sheepqtldb",
     "uri_format": "https://www.animalgenome.org/QTLdb/q?id=QTL_ID:$1",
     "prefix": "sheepqtldb",
-    "all_prefixes": [
+    "synonyms": [
       "sheepqtldb"
     ]
   },
@@ -10512,7 +10512,7 @@
     "preferred_prefix": "SIBO",
     "uri_format": "http://purl.obolibrary.org/obo/SIBO_$1",
     "prefix": "sibo",
-    "all_prefixes": [
+    "synonyms": [
       "sibo"
     ]
   },
@@ -10523,7 +10523,7 @@
     "preferred_prefix": "sider.drug",
     "uri_format": "http://sideeffects.embl.de/drugs/$1",
     "prefix": "sider.drug",
-    "all_prefixes": [
+    "synonyms": [
       "sider.drug"
     ]
   },
@@ -10534,7 +10534,7 @@
     "preferred_prefix": "sider.effect",
     "uri_format": "http://sideeffects.embl.de/se/$1",
     "prefix": "sider.effect",
-    "all_prefixes": [
+    "synonyms": [
       "sider.effect"
     ]
   },
@@ -10544,7 +10544,7 @@
     "preferred_prefix": "sigmaaldirch",
     "uri_format": "https://www.sigmaaldrich.com/US/en/product/sigma/$1",
     "prefix": "sigmaaldirch",
-    "all_prefixes": [
+    "synonyms": [
       "sigmaaldirch"
     ]
   },
@@ -10555,7 +10555,7 @@
     "preferred_prefix": "signaling-gateway",
     "uri_format": "http://www.signaling-gateway.org/molecule/query?afcsid=$1",
     "prefix": "signaling-gateway",
-    "all_prefixes": [
+    "synonyms": [
       "signaling-gateway"
     ]
   },
@@ -10566,7 +10566,7 @@
     "preferred_prefix": "signor",
     "uri_format": "https://signor.uniroma2.it/relation_result.php?id=$1",
     "prefix": "signor",
-    "all_prefixes": [
+    "synonyms": [
       "signor"
     ]
   },
@@ -10577,7 +10577,7 @@
     "preferred_prefix": "sio",
     "uri_format": "https://www.ebi.ac.uk/ols/ontologies/sio/terms?short_form=$1",
     "prefix": "sio",
-    "all_prefixes": [
+    "synonyms": [
       "sio"
     ]
   },
@@ -10588,7 +10588,7 @@
     "preferred_prefix": "sisu",
     "uri_format": "http://search.sisuproject.fi/#/variant/$1",
     "prefix": "sisu",
-    "all_prefixes": [
+    "synonyms": [
       "sisu"
     ]
   },
@@ -10599,7 +10599,7 @@
     "preferred_prefix": "sitex",
     "uri_format": "http://www-bionet.sscc.ru/sitex/index.php?siteid=$1",
     "prefix": "sitex",
-    "all_prefixes": [
+    "synonyms": [
       "sitex"
     ]
   },
@@ -10609,7 +10609,7 @@
     "preferred_prefix": "skip",
     "uri_format": "https://skip.stemcellinformatics.org/SKIPSearch/cell_line_detail?accession=$1",
     "prefix": "skip",
-    "all_prefixes": [
+    "synonyms": [
       "skip"
     ]
   },
@@ -10619,7 +10619,7 @@
     "preferred_prefix": "skos",
     "uri_format": "http://www.w3.org/2004/02/skos/core#$1",
     "prefix": "skos",
-    "all_prefixes": [
+    "synonyms": [
       "skos"
     ]
   },
@@ -10630,7 +10630,7 @@
     "preferred_prefix": "smart",
     "uri_format": "http://smart.embl-heidelberg.de/smart/do_annotation.pl?DOMAIN=$1",
     "prefix": "smart",
-    "all_prefixes": [
+    "synonyms": [
       "smart"
     ]
   },
@@ -10640,7 +10640,7 @@
     "preferred_prefix": "smid",
     "uri_format": "https://smid-db.org/smid/$1",
     "prefix": "smid",
-    "all_prefixes": [
+    "synonyms": [
       "smid",
       "smid-db"
     ]
@@ -10652,7 +10652,7 @@
     "preferred_prefix": "smpdb",
     "uri_format": "https://smpdb.ca/view/$1",
     "prefix": "smpdb",
-    "all_prefixes": [
+    "synonyms": [
       "smp",
       "smpdb"
     ]
@@ -10664,7 +10664,7 @@
     "preferred_prefix": "snomedct",
     "uri_format": "http://www.snomedbrowser.com/Codes/Details/$1",
     "prefix": "snomedct",
-    "all_prefixes": [
+    "synonyms": [
       "sctid",
       "sctid_2010_1_31",
       "snomect",
@@ -10695,7 +10695,7 @@
     "preferred_prefix": "snp2tfbs",
     "uri_format": "https://ccg.epfl.ch/cgi-bin/snp2tfbs/snpviewer_form_parser.cgi?snpid=$1",
     "prefix": "snp2tfbs",
-    "all_prefixes": [
+    "synonyms": [
       "snp2tfbs"
     ]
   },
@@ -10706,7 +10706,7 @@
     "preferred_prefix": "SO",
     "uri_format": "http://www.sequenceontology.org/miso/current_release/term/SO:$1",
     "prefix": "so",
-    "all_prefixes": [
+    "synonyms": [
       "so"
     ]
   },
@@ -10716,7 +10716,7 @@
     "preferred_prefix": "SOPHARM",
     "uri_format": "http://purl.obolibrary.org/obo/SOPHARM_$1",
     "prefix": "sopharm",
-    "all_prefixes": [
+    "synonyms": [
       "sopharm"
     ]
   },
@@ -10727,7 +10727,7 @@
     "preferred_prefix": "soybase",
     "uri_format": "http://www.soybase.org/sbt/search/search_results.php?category=SNP&search_term=$1",
     "prefix": "soybase",
-    "all_prefixes": [
+    "synonyms": [
       "soybase"
     ]
   },
@@ -10738,7 +10738,7 @@
     "preferred_prefix": "SPD",
     "uri_format": "http://purl.obolibrary.org/obo/SPD_$1",
     "prefix": "spd",
-    "all_prefixes": [
+    "synonyms": [
       "spd"
     ]
   },
@@ -10749,7 +10749,7 @@
     "preferred_prefix": "spdx",
     "uri_format": "https://spdx.org/licenses/$1",
     "prefix": "spdx",
-    "all_prefixes": [
+    "synonyms": [
       "spdx"
     ]
   },
@@ -10760,7 +10760,7 @@
     "preferred_prefix": "spike.map",
     "uri_format": "http://www.cs.tau.ac.il/~spike/maps/$1.html",
     "prefix": "spike.map",
-    "all_prefixes": [
+    "synonyms": [
       "spike.map"
     ]
   },
@@ -10771,7 +10771,7 @@
     "preferred_prefix": "splash",
     "uri_format": "http://mona.fiehnlab.ucdavis.edu/#/spectra/splash/$1",
     "prefix": "splash",
-    "all_prefixes": [
+    "synonyms": [
       "splash"
     ]
   },
@@ -10782,7 +10782,7 @@
     "preferred_prefix": "spp",
     "uri_format": "https://www.signalingpathways.org/datasets/dataset.jsf?doi=$1",
     "prefix": "spp",
-    "all_prefixes": [
+    "synonyms": [
       "spp"
     ]
   },
@@ -10792,7 +10792,7 @@
     "preferred_prefix": "ssbd.dataset",
     "uri_format": "https://ssbd.riken.jp/database/dataset/$1",
     "prefix": "ssbd.dataset",
-    "all_prefixes": [
+    "synonyms": [
       "ssbd.dataset"
     ]
   },
@@ -10802,7 +10802,7 @@
     "preferred_prefix": "ssbd.project",
     "uri_format": "https://ssbd.riken.jp/database/project/$1",
     "prefix": "ssbd.project",
-    "all_prefixes": [
+    "synonyms": [
       "ssbd.project"
     ]
   },
@@ -10813,7 +10813,7 @@
     "preferred_prefix": "stap",
     "uri_format": "http://psb.kobic.re.kr/STAP/refinement1/result.php?search=$1",
     "prefix": "stap",
-    "all_prefixes": [
+    "synonyms": [
       "stap"
     ]
   },
@@ -10823,7 +10823,7 @@
     "preferred_prefix": "STATO",
     "uri_format": "http://purl.obolibrary.org/obo/STATO_$1",
     "prefix": "stato",
-    "all_prefixes": [
+    "synonyms": [
       "stato"
     ]
   },
@@ -10834,7 +10834,7 @@
     "preferred_prefix": "stitch",
     "uri_format": "http://stitch.embl.de/interactions/$1",
     "prefix": "stitch",
-    "all_prefixes": [
+    "synonyms": [
       "stitch"
     ]
   },
@@ -10845,7 +10845,7 @@
     "preferred_prefix": "storedb",
     "uri_format": "https://www.storedb.org/?$1",
     "prefix": "storedb",
-    "all_prefixes": [
+    "synonyms": [
       "storedb"
     ]
   },
@@ -10856,7 +10856,7 @@
     "preferred_prefix": "string",
     "uri_format": "http://string.embl.de/interactions/$1",
     "prefix": "string",
-    "all_prefixes": [
+    "synonyms": [
       "string"
     ]
   },
@@ -10867,7 +10867,7 @@
     "preferred_prefix": "sty",
     "uri_format": "http://purl.bioontology.org/ontology/STY/$1",
     "prefix": "sty",
-    "all_prefixes": [
+    "synonyms": [
       "sty"
     ]
   },
@@ -10878,7 +10878,7 @@
     "preferred_prefix": "subtilist",
     "uri_format": "http://genolist.pasteur.fr/SubtiList/genome.cgi?external_query+$1",
     "prefix": "subtilist",
-    "all_prefixes": [
+    "synonyms": [
       "subtilist"
     ]
   },
@@ -10889,7 +10889,7 @@
     "preferred_prefix": "subtiwiki",
     "uri_format": "http://www.subtiwiki.uni-goettingen.de/wiki/index.php/$1",
     "prefix": "subtiwiki",
-    "all_prefixes": [
+    "synonyms": [
       "subtiwiki"
     ]
   },
@@ -10900,7 +10900,7 @@
     "preferred_prefix": "sugarbind",
     "uri_format": "http://sugarbind.expasy.org/$1",
     "prefix": "sugarbind",
-    "all_prefixes": [
+    "synonyms": [
       "sugarbind"
     ]
   },
@@ -10911,7 +10911,7 @@
     "preferred_prefix": "supfam",
     "uri_format": "http://supfam.org/SUPERFAMILY/cgi-bin/scop.cgi?ipid=$1",
     "prefix": "supfam",
-    "all_prefixes": [
+    "synonyms": [
       "supfam"
     ]
   },
@@ -10922,7 +10922,7 @@
     "preferred_prefix": "swh",
     "uri_format": "https://archive.softwareheritage.org/browse/swh:$1",
     "prefix": "swh",
-    "all_prefixes": [
+    "synonyms": [
       "swh"
     ]
   },
@@ -10933,7 +10933,7 @@
     "preferred_prefix": "swiss-model",
     "uri_format": "https://swissmodel.expasy.org/repository/uniprot/$1",
     "prefix": "swiss-model",
-    "all_prefixes": [
+    "synonyms": [
       "swiss-model"
     ]
   },
@@ -10944,7 +10944,7 @@
     "preferred_prefix": "swisslipid",
     "uri_format": "https://www.swisslipids.org/#/entity/SLM:$1",
     "prefix": "swisslipid",
-    "all_prefixes": [
+    "synonyms": [
       "slm",
       "swisslipid",
       "swisslipids"
@@ -10957,7 +10957,7 @@
     "preferred_prefix": "swissregulon",
     "uri_format": "http://swissregulon.unibas.ch/query/$1",
     "prefix": "swissregulon",
-    "all_prefixes": [
+    "synonyms": [
       "swissregulon"
     ]
   },
@@ -10968,7 +10968,7 @@
     "preferred_prefix": "SWO",
     "uri_format": "http://purl.obolibrary.org/obo/SWO_$1",
     "prefix": "swo",
-    "all_prefixes": [
+    "synonyms": [
       "swo"
     ]
   },
@@ -10979,7 +10979,7 @@
     "preferred_prefix": "SYMP",
     "uri_format": "http://purl.obolibrary.org/obo/SYMP_$1",
     "prefix": "symp",
-    "all_prefixes": [
+    "synonyms": [
       "symp"
     ]
   },
@@ -10990,7 +10990,7 @@
     "preferred_prefix": "t3db",
     "uri_format": "http://www.t3db.org/toxins/$1",
     "prefix": "t3db",
-    "all_prefixes": [
+    "synonyms": [
       "t3db"
     ]
   },
@@ -11001,7 +11001,7 @@
     "preferred_prefix": "TADS",
     "uri_format": "http://purl.obolibrary.org/obo/TADS_$1",
     "prefix": "tads",
-    "all_prefixes": [
+    "synonyms": [
       "tads"
     ]
   },
@@ -11011,7 +11011,7 @@
     "preferred_prefix": "TAHE",
     "uri_format": "http://purl.obolibrary.org/obo/TAHE_$1",
     "prefix": "tahe",
-    "all_prefixes": [
+    "synonyms": [
       "tahe"
     ]
   },
@@ -11021,7 +11021,7 @@
     "preferred_prefix": "TAHH",
     "uri_format": "http://purl.obolibrary.org/obo/TAHH_$1",
     "prefix": "tahh",
-    "all_prefixes": [
+    "synonyms": [
       "tahh"
     ]
   },
@@ -11032,7 +11032,7 @@
     "preferred_prefix": "tair.gene",
     "uri_format": "http://arabidopsis.org/servlets/TairObject?accession=Gene:$1",
     "prefix": "tair.gene",
-    "all_prefixes": [
+    "synonyms": [
       "tair.gene"
     ]
   },
@@ -11043,7 +11043,7 @@
     "preferred_prefix": "tair.locus",
     "uri_format": "http://www.arabidopsis.org/servlets/TairObject?accession=Locus:$1",
     "prefix": "tair.locus",
-    "all_prefixes": [
+    "synonyms": [
       "tair.locus"
     ]
   },
@@ -11054,7 +11054,7 @@
     "preferred_prefix": "tair.protein",
     "uri_format": "http://arabidopsis.org/servlets/TairObject?accession=AASequence:$1",
     "prefix": "tair.protein",
-    "all_prefixes": [
+    "synonyms": [
       "tair.protein"
     ]
   },
@@ -11065,7 +11065,7 @@
     "preferred_prefix": "TAO",
     "uri_format": "http://purl.obolibrary.org/obo/TAO_$1",
     "prefix": "tao",
-    "all_prefixes": [
+    "synonyms": [
       "tao",
       "tao_retired"
     ]
@@ -11077,7 +11077,7 @@
     "preferred_prefix": "tarbase",
     "uri_format": "http://diana.imis.athena-innovation.gr/DianaTools/index.php?r=tarbase/index&mirnas=$1",
     "prefix": "tarbase",
-    "all_prefixes": [
+    "synonyms": [
       "tarbase"
     ]
   },
@@ -11088,7 +11088,7 @@
     "preferred_prefix": "TAXRANK",
     "uri_format": "http://purl.obolibrary.org/obo/TAXRANK_$1",
     "prefix": "taxrank",
-    "all_prefixes": [
+    "synonyms": [
       "taxrank"
     ]
   },
@@ -11099,7 +11099,7 @@
     "preferred_prefix": "tcdb",
     "uri_format": "http://www.tcdb.org/search/result.php?tc=$1",
     "prefix": "tcdb",
-    "all_prefixes": [
+    "synonyms": [
       "tc",
       "tcdb"
     ]
@@ -11110,7 +11110,7 @@
     "preferred_prefix": "tfclass",
     "uri_format": "http://tfclass.bioinf.med.uni-goettingen.de/?tfclass=$1",
     "prefix": "tfclass",
-    "all_prefixes": [
+    "synonyms": [
       "tfclass"
     ]
   },
@@ -11121,7 +11121,7 @@
     "preferred_prefix": "tgd",
     "uri_format": "http://ciliate.org/index.php/feature/details/$1",
     "prefix": "tgd",
-    "all_prefixes": [
+    "synonyms": [
       "tgd"
     ]
   },
@@ -11132,7 +11132,7 @@
     "preferred_prefix": "TGMA",
     "uri_format": "http://purl.obolibrary.org/obo/TGMA_$1",
     "prefix": "tgma",
-    "all_prefixes": [
+    "synonyms": [
       "tgma"
     ]
   },
@@ -11142,7 +11142,7 @@
     "preferred_prefix": "thermofisher",
     "uri_format": "https://www.thermofisher.com/antibody/product/$1",
     "prefix": "thermofisher",
-    "all_prefixes": [
+    "synonyms": [
       "thermofisher"
     ]
   },
@@ -11153,7 +11153,7 @@
     "preferred_prefix": "tigrfam",
     "uri_format": "http://www.jcvi.org/cgi-bin/tigrfams/HmmReportPage.cgi?acc=$1",
     "prefix": "tigrfam",
-    "all_prefixes": [
+    "synonyms": [
       "tigrfam"
     ]
   },
@@ -11164,7 +11164,7 @@
     "preferred_prefix": "tkg",
     "uri_format": "http://www2.idac.tohoku.ac.jp/dep/ccr/TKGdate/TKGvol08/$1.html",
     "prefix": "tkg",
-    "all_prefixes": [
+    "synonyms": [
       "tkg"
     ]
   },
@@ -11175,7 +11175,7 @@
     "preferred_prefix": "TO",
     "uri_format": "http://purl.obolibrary.org/obo/TO_$1",
     "prefix": "to",
-    "all_prefixes": [
+    "synonyms": [
       "to"
     ]
   },
@@ -11186,7 +11186,7 @@
     "preferred_prefix": "tol",
     "uri_format": "http://tolweb.org/$1",
     "prefix": "tol",
-    "all_prefixes": [
+    "synonyms": [
       "tol"
     ]
   },
@@ -11197,7 +11197,7 @@
     "preferred_prefix": "topdb",
     "uri_format": "http://topdb.enzim.hu/?m=show&id=$1",
     "prefix": "topdb",
-    "all_prefixes": [
+    "synonyms": [
       "topdb"
     ]
   },
@@ -11208,7 +11208,7 @@
     "preferred_prefix": "topfind",
     "uri_format": "http://clipserve.clip.ubc.ca/topfind/proteins/$1",
     "prefix": "topfind",
-    "all_prefixes": [
+    "synonyms": [
       "topfind"
     ]
   },
@@ -11219,7 +11219,7 @@
     "preferred_prefix": "toxoplasma",
     "uri_format": "http://toxodb.org/toxo/showRecord.do?name=GeneRecordClasses.GeneRecordClass&source_id=$1",
     "prefix": "toxoplasma",
-    "all_prefixes": [
+    "synonyms": [
       "toxoplasma"
     ]
   },
@@ -11230,7 +11230,7 @@
     "preferred_prefix": "TRANS",
     "uri_format": "http://purl.obolibrary.org/obo/TRANS_$1",
     "prefix": "trans",
-    "all_prefixes": [
+    "synonyms": [
       "trans"
     ]
   },
@@ -11241,7 +11241,7 @@
     "preferred_prefix": "transyt",
     "uri_format": "https://transyt.bio.di.uminho.pt/reactions/$1",
     "prefix": "transyt",
-    "all_prefixes": [
+    "synonyms": [
       "transyt"
     ]
   },
@@ -11252,7 +11252,7 @@
     "preferred_prefix": "treebase",
     "uri_format": "http://purl.org/phylo/treebase/phylows/study/$1?format=html",
     "prefix": "treebase",
-    "all_prefixes": [
+    "synonyms": [
       "treebase"
     ]
   },
@@ -11263,7 +11263,7 @@
     "preferred_prefix": "treefam",
     "uri_format": "http://www.treefam.org/family/$1",
     "prefix": "treefam",
-    "all_prefixes": [
+    "synonyms": [
       "treefam"
     ]
   },
@@ -11274,7 +11274,7 @@
     "preferred_prefix": "trichdb",
     "uri_format": "http://trichdb.org/trichdb/showRecord.do?name=GeneRecordClasses.GeneRecordClass&source_id=$1",
     "prefix": "trichdb",
-    "all_prefixes": [
+    "synonyms": [
       "trichdb"
     ]
   },
@@ -11285,7 +11285,7 @@
     "preferred_prefix": "tritrypdb",
     "uri_format": "http://tritrypdb.org/tritrypdb/showRecord.do?name=GeneRecordClasses.GeneRecordClass&source_id=$1",
     "prefix": "tritrypdb",
-    "all_prefixes": [
+    "synonyms": [
       "tritrypdb"
     ]
   },
@@ -11296,7 +11296,7 @@
     "preferred_prefix": "ttd.drug",
     "uri_format": "http://bidd.nus.edu.sg/group/TTD/ZFTTDDRUG.asp?ID=$1",
     "prefix": "ttd.drug",
-    "all_prefixes": [
+    "synonyms": [
       "ttd.drug"
     ]
   },
@@ -11307,7 +11307,7 @@
     "preferred_prefix": "ttd.target",
     "uri_format": "http://bidd.nus.edu.sg/group/TTD/ZFTTDDetail.asp?ID=$1",
     "prefix": "ttd.target",
-    "all_prefixes": [
+    "synonyms": [
       "ttd.target"
     ]
   },
@@ -11318,7 +11318,7 @@
     "preferred_prefix": "TTO",
     "uri_format": "http://purl.obolibrary.org/obo/TTO_$1",
     "prefix": "tto",
-    "all_prefixes": [
+    "synonyms": [
       "tto"
     ]
   },
@@ -11328,7 +11328,7 @@
     "preferred_prefix": "TXPO",
     "uri_format": "http://purl.obolibrary.org/obo/TXPO_$1",
     "prefix": "txpo",
-    "all_prefixes": [
+    "synonyms": [
       "txpo"
     ]
   },
@@ -11339,7 +11339,7 @@
     "preferred_prefix": "UBERON",
     "uri_format": "http://purl.bioontology.org/ontology/UBERON/UBERON:$1",
     "prefix": "uberon",
-    "all_prefixes": [
+    "synonyms": [
       "uberon"
     ]
   },
@@ -11350,7 +11350,7 @@
     "preferred_prefix": "ubio.namebank",
     "uri_format": "http://www.ubio.org/browser/details.php?namebankID=$1",
     "prefix": "ubio.namebank",
-    "all_prefixes": [
+    "synonyms": [
       "ubio.namebank"
     ]
   },
@@ -11360,7 +11360,7 @@
     "preferred_prefix": "ucsc",
     "uri_format": "ftp://hgdownload.cse.ucsc.edu/goldenPath/$1",
     "prefix": "ucsc",
-    "all_prefixes": [
+    "synonyms": [
       "ucsc"
     ]
   },
@@ -11371,7 +11371,7 @@
     "preferred_prefix": "umbbd.compound",
     "uri_format": "http://eawag-bbd.ethz.ch/servlets/pageservlet?ptype=c&compID=$1",
     "prefix": "umbbd.compound",
-    "all_prefixes": [
+    "synonyms": [
       "um-bbd_compid",
       "umbbd.compound"
     ]
@@ -11383,7 +11383,7 @@
     "preferred_prefix": "umbbd.enzyme",
     "uri_format": "http://eawag-bbd.ethz.ch/servlets/pageservlet?ptype=ep&enzymeID=$1",
     "prefix": "umbbd.enzyme",
-    "all_prefixes": [
+    "synonyms": [
       "um-bbd_enzymeid",
       "umbbd.enzyme"
     ]
@@ -11395,7 +11395,7 @@
     "preferred_prefix": "umbbd.pathway",
     "uri_format": "http://eawag-bbd.ethz.ch/$1/$1_map.html",
     "prefix": "umbbd.pathway",
-    "all_prefixes": [
+    "synonyms": [
       "um-bbd_pathwayid",
       "umbbd.pathway"
     ]
@@ -11407,7 +11407,7 @@
     "preferred_prefix": "umbbd.reaction",
     "uri_format": "http://eawag-bbd.ethz.ch/servlets/pageservlet?ptype=r&reacID=$1",
     "prefix": "umbbd.reaction",
-    "all_prefixes": [
+    "synonyms": [
       "um-bbd_reactionid",
       "umbbd.reaction"
     ]
@@ -11419,7 +11419,7 @@
     "preferred_prefix": "umbbd.rule",
     "uri_format": "http://www.umbbd.ethz.ch/servlets/rule.jsp?rule=$1",
     "prefix": "umbbd.rule",
-    "all_prefixes": [
+    "synonyms": [
       "um-bbd_ruleid",
       "umbbd.rule"
     ]
@@ -11431,7 +11431,7 @@
     "preferred_prefix": "umls",
     "uri_format": "http://linkedlifedata.com/resource/umls/id/$1",
     "prefix": "umls",
-    "all_prefixes": [
+    "synonyms": [
       "umls",
       "umls_cui"
     ]
@@ -11443,7 +11443,7 @@
     "preferred_prefix": "unigene",
     "uri_format": "http://www.ncbi.nlm.nih.gov/UniGene/clust.cgi?UGID=$1",
     "prefix": "unigene",
-    "all_prefixes": [
+    "synonyms": [
       "unigene"
     ]
   },
@@ -11454,7 +11454,7 @@
     "preferred_prefix": "unii",
     "uri_format": "http://fdasis.nlm.nih.gov/srs/srsdirect.jsp?regno=$1",
     "prefix": "unii",
-    "all_prefixes": [
+    "synonyms": [
       "unii"
     ]
   },
@@ -11465,7 +11465,7 @@
     "preferred_prefix": "unimod",
     "uri_format": "http://www.unimod.org/modifications_view.php?editid1=$1",
     "prefix": "unimod",
-    "all_prefixes": [
+    "synonyms": [
       "unimod"
     ]
   },
@@ -11476,7 +11476,7 @@
     "preferred_prefix": "uniparc",
     "uri_format": "https://www.ebi.ac.uk/cgi-bin/dbfetch?db=uniparc&id=$1",
     "prefix": "uniparc",
-    "all_prefixes": [
+    "synonyms": [
       "uniparc"
     ]
   },
@@ -11487,7 +11487,7 @@
     "preferred_prefix": "unipathway.compound",
     "uri_format": "http://www.grenoble.prabi.fr/obiwarehouse/unipathway/upc?upid=$1",
     "prefix": "unipathway.compound",
-    "all_prefixes": [
+    "synonyms": [
       "unipathway.compound"
     ]
   },
@@ -11498,7 +11498,7 @@
     "preferred_prefix": "unipathway.reaction",
     "uri_format": "http://www.grenoble.prabi.fr/obiwarehouse/unipathway/ucr?upid=$1",
     "prefix": "unipathway.reaction",
-    "all_prefixes": [
+    "synonyms": [
       "unipathway.reaction"
     ]
   },
@@ -11509,7 +11509,7 @@
     "preferred_prefix": "uniprot",
     "uri_format": "http://purl.uniprot.org/uniprot/$1",
     "prefix": "uniprot",
-    "all_prefixes": [
+    "synonyms": [
       "swissprot",
       "uniprot",
       "uniprotkb",
@@ -11523,7 +11523,7 @@
     "preferred_prefix": "uniprot.chain",
     "uri_format": "http://purl.uniprot.org/annotation/$1",
     "prefix": "uniprot.chain",
-    "all_prefixes": [
+    "synonyms": [
       "uniprot.chain",
       "uppro"
     ]
@@ -11534,7 +11534,7 @@
     "preferred_prefix": "uniprot.disease",
     "uri_format": "https://www.uniprot.org/diseases/DI-$1",
     "prefix": "uniprot.disease",
-    "all_prefixes": [
+    "synonyms": [
       "di",
       "uniprot.disease"
     ]
@@ -11546,7 +11546,7 @@
     "preferred_prefix": "uniprot.isoform",
     "uri_format": "http://www.uniprot.org/uniprot/$1",
     "prefix": "uniprot.isoform",
-    "all_prefixes": [
+    "synonyms": [
       "uniprot.isoform",
       "upiso"
     ]
@@ -11557,7 +11557,7 @@
     "preferred_prefix": "uniprot.keyword",
     "uri_format": "https://www.uniprot.org/keywords/$1",
     "prefix": "uniprot.keyword",
-    "all_prefixes": [
+    "synonyms": [
       "uniprot.keyword",
       "uniprotkb-kw"
     ]
@@ -11569,7 +11569,7 @@
     "preferred_prefix": "uniprot.location",
     "uri_format": "https://www.uniprot.org/locations/SL-$1",
     "prefix": "uniprot.location",
-    "all_prefixes": [
+    "synonyms": [
       "uniprot.location",
       "uniprotkb-subcell",
       "uploc"
@@ -11582,7 +11582,7 @@
     "preferred_prefix": "uniprot.tissue",
     "uri_format": "https://www.uniprot.org/tissues/$1",
     "prefix": "uniprot.tissue",
-    "all_prefixes": [
+    "synonyms": [
       "uniprot.tissue"
     ]
   },
@@ -11593,7 +11593,7 @@
     "preferred_prefix": "uniprot.var",
     "uri_format": "https://web.expasy.org/variant_pages/$1.html",
     "prefix": "uniprot.var",
-    "all_prefixes": [
+    "synonyms": [
       "uniprot.var",
       "uniprotkb_var"
     ]
@@ -11605,7 +11605,7 @@
     "preferred_prefix": "uniref",
     "uri_format": "https://www.uniprot.org/uniref/$1",
     "prefix": "uniref",
-    "all_prefixes": [
+    "synonyms": [
       "uniref"
     ]
   },
@@ -11615,7 +11615,7 @@
     "preferred_prefix": "unirule",
     "uri_format": "https://www.uniprot.org/unirule/$1",
     "prefix": "unirule",
-    "all_prefixes": [
+    "synonyms": [
       "unirule"
     ]
   },
@@ -11626,7 +11626,7 @@
     "preferred_prefix": "unists",
     "uri_format": "https://www.ncbi.nlm.nih.gov/genome/sts/sts.cgi?uid=$1",
     "prefix": "unists",
-    "all_prefixes": [
+    "synonyms": [
       "unists"
     ]
   },
@@ -11637,7 +11637,7 @@
     "preferred_prefix": "unite",
     "uri_format": "http://unite.ut.ee/bl_forw.php?nimi=$1",
     "prefix": "unite",
-    "all_prefixes": [
+    "synonyms": [
       "unite"
     ]
   },
@@ -11648,7 +11648,7 @@
     "preferred_prefix": "UO",
     "uri_format": "https://www.ebi.ac.uk/ols/ontologies/uo/terms?obo_id=UO:$1",
     "prefix": "uo",
-    "all_prefixes": [
+    "synonyms": [
       "uo"
     ]
   },
@@ -11660,7 +11660,7 @@
     "preferred_prefix": "UPA",
     "uri_format": "http://www.grenoble.prabi.fr/obiwarehouse/unipathway/upa?upid=$1",
     "prefix": "upa",
-    "all_prefixes": [
+    "synonyms": [
       "unipathway",
       "upa"
     ]
@@ -11670,7 +11670,7 @@
     "preferred_prefix": "UPHENO",
     "uri_format": "http://purl.obolibrary.org/obo/UPHENO_$1",
     "prefix": "upheno",
-    "all_prefixes": [
+    "synonyms": [
       "upheno"
     ]
   },
@@ -11681,7 +11681,7 @@
     "preferred_prefix": "uspto",
     "uri_format": "http://patft.uspto.gov/netacgi/nph-Parser?Sect2=PTO1&Sect2=HITOFF&p=1&u=/netahtml/PTO/search-bool.html&r=1&f=G&l=50&d=PALL&RefSrch=yes&Query=PN/$1",
     "prefix": "uspto",
-    "all_prefixes": [
+    "synonyms": [
       "uspto"
     ]
   },
@@ -11692,7 +11692,7 @@
     "preferred_prefix": "validatordb",
     "uri_format": "https://webchem.ncbr.muni.cz/Platform/ValidatorDb/ByStructure/$1",
     "prefix": "validatordb",
-    "all_prefixes": [
+    "synonyms": [
       "validatordb"
     ]
   },
@@ -11703,7 +11703,7 @@
     "preferred_prefix": "VariO",
     "uri_format": "http://purl.bioontology.org/ontology/VARIO/VariO:$1",
     "prefix": "vario",
-    "all_prefixes": [
+    "synonyms": [
       "vario"
     ]
   },
@@ -11714,7 +11714,7 @@
     "preferred_prefix": "vbase2",
     "uri_format": "http://www.vbase2.org/vgene.php?id=$1",
     "prefix": "vbase2",
-    "all_prefixes": [
+    "synonyms": [
       "vbase2"
     ]
   },
@@ -11725,7 +11725,7 @@
     "preferred_prefix": "vbrc",
     "uri_format": "http://vbrc.org/gene_detail.asp?gene_id=$1",
     "prefix": "vbrc",
-    "all_prefixes": [
+    "synonyms": [
       "vbrc"
     ]
   },
@@ -11736,7 +11736,7 @@
     "preferred_prefix": "vectorbase",
     "uri_format": "https://vectorbase.org/vectorbase/app/record/gene/$1",
     "prefix": "vectorbase",
-    "all_prefixes": [
+    "synonyms": [
       "vectorbase"
     ]
   },
@@ -11747,7 +11747,7 @@
     "preferred_prefix": "vegbank",
     "uri_format": "http://vegbank.org/cite/$1",
     "prefix": "vegbank",
-    "all_prefixes": [
+    "synonyms": [
       "vegbank"
     ]
   },
@@ -11758,7 +11758,7 @@
     "preferred_prefix": "vfb",
     "uri_format": "http://virtualflybrain.org/reports/$1",
     "prefix": "vfb",
-    "all_prefixes": [
+    "synonyms": [
       "vfb"
     ]
   },
@@ -11769,7 +11769,7 @@
     "preferred_prefix": "vfdb.gene",
     "uri_format": "http://www.mgc.ac.cn/cgi-bin/VFs/gene.cgi?GeneID=$1",
     "prefix": "vfdb.gene",
-    "all_prefixes": [
+    "synonyms": [
       "vfdb.gene"
     ]
   },
@@ -11780,7 +11780,7 @@
     "preferred_prefix": "vfdb.genus",
     "uri_format": "http://www.mgc.ac.cn/cgi-bin/VFs/genus.cgi?Genus=$1",
     "prefix": "vfdb.genus",
-    "all_prefixes": [
+    "synonyms": [
       "vfdb.genus"
     ]
   },
@@ -11791,7 +11791,7 @@
     "preferred_prefix": "vgnc",
     "uri_format": "https://vertebrate.genenames.org/data/gene-symbol-report/#!/vgnc_id/$1",
     "prefix": "vgnc",
-    "all_prefixes": [
+    "synonyms": [
       "vgnc"
     ]
   },
@@ -11802,7 +11802,7 @@
     "preferred_prefix": "VHOG",
     "uri_format": "http://purl.obolibrary.org/obo/VHOG_$1",
     "prefix": "vhog",
-    "all_prefixes": [
+    "synonyms": [
       "vhog",
       "vhog_retired"
     ]
@@ -11814,7 +11814,7 @@
     "preferred_prefix": "viaf",
     "uri_format": "http://viaf.org/viaf/$1",
     "prefix": "viaf",
-    "all_prefixes": [
+    "synonyms": [
       "viaf"
     ]
   },
@@ -11825,7 +11825,7 @@
     "preferred_prefix": "vipr",
     "uri_format": "http://www.viprbrc.org/brc/viprStrainDetails.do?strainName=$1&decorator=arena",
     "prefix": "vipr",
-    "all_prefixes": [
+    "synonyms": [
       "vipr"
     ]
   },
@@ -11836,7 +11836,7 @@
     "preferred_prefix": "viralzone",
     "uri_format": "http://viralzone.expasy.org/all_by_protein/$1.html",
     "prefix": "viralzone",
-    "all_prefixes": [
+    "synonyms": [
       "viralzone"
     ]
   },
@@ -11847,7 +11847,7 @@
     "preferred_prefix": "virsirna",
     "uri_format": "http://crdd.osdd.net/servers/virsirnadb/record.php?details=$1",
     "prefix": "virsirna",
-    "all_prefixes": [
+    "synonyms": [
       "virsirna"
     ]
   },
@@ -11858,7 +11858,7 @@
     "preferred_prefix": "vmhgene",
     "uri_format": "https://www.vmh.life/#gene/$1",
     "prefix": "vmhgene",
-    "all_prefixes": [
+    "synonyms": [
       "vmhgene"
     ]
   },
@@ -11869,7 +11869,7 @@
     "preferred_prefix": "vmhmetabolite",
     "uri_format": "https://www.vmh.life/#metabolite/$1",
     "prefix": "vmhmetabolite",
-    "all_prefixes": [
+    "synonyms": [
       "vmhmetabolite"
     ]
   },
@@ -11880,7 +11880,7 @@
     "preferred_prefix": "vmhreaction",
     "uri_format": "https://www.vmh.life/#reaction/$1",
     "prefix": "vmhreaction",
-    "all_prefixes": [
+    "synonyms": [
       "vmhreaction"
     ]
   },
@@ -11890,7 +11890,7 @@
     "preferred_prefix": "VO",
     "uri_format": "http://purl.obolibrary.org/obo/VO_$1",
     "prefix": "vo",
-    "all_prefixes": [
+    "synonyms": [
       "vo"
     ]
   },
@@ -11900,7 +11900,7 @@
     "preferred_prefix": "void",
     "uri_format": "http://rdfs.org/ns/void#$1",
     "prefix": "void",
-    "all_prefixes": [
+    "synonyms": [
       "void"
     ]
   },
@@ -11910,7 +11910,7 @@
     "preferred_prefix": "VSAO",
     "uri_format": "http://purl.obolibrary.org/obo/VSAO_$1",
     "prefix": "vsao",
-    "all_prefixes": [
+    "synonyms": [
       "vsao",
       "vsao_retired"
     ]
@@ -11921,7 +11921,7 @@
     "preferred_prefix": "vsdb",
     "uri_format": "https://sitem.herts.ac.uk/aeru/vsdb/Reports/$1.htm",
     "prefix": "vsdb",
-    "all_prefixes": [
+    "synonyms": [
       "vsdb"
     ]
   },
@@ -11932,7 +11932,7 @@
     "preferred_prefix": "VT",
     "uri_format": "http://purl.obolibrary.org/obo/VT_$1",
     "prefix": "vt",
-    "all_prefixes": [
+    "synonyms": [
       "vt"
     ]
   },
@@ -11943,7 +11943,7 @@
     "preferred_prefix": "VTO",
     "uri_format": "http://purl.obolibrary.org/obo/VTO_$1",
     "prefix": "vto",
-    "all_prefixes": [
+    "synonyms": [
       "vto"
     ]
   },
@@ -11953,7 +11953,7 @@
     "preferred_prefix": "vz",
     "uri_format": "https://viralzone.expasy.org/$1",
     "prefix": "vz",
-    "all_prefixes": [
+    "synonyms": [
       "vz"
     ]
   },
@@ -11964,7 +11964,7 @@
     "preferred_prefix": "wb.rnai",
     "uri_format": "https://www.wormbase.org/species/c_elegans/rnai/$1",
     "prefix": "wb.rnai",
-    "all_prefixes": [
+    "synonyms": [
       "wb.rnai"
     ]
   },
@@ -11975,7 +11975,7 @@
     "preferred_prefix": "WBbt",
     "uri_format": "http://purl.obolibrary.org/obo/WBBT_$1",
     "prefix": "wbbt",
-    "all_prefixes": [
+    "synonyms": [
       "wbbt"
     ]
   },
@@ -11986,7 +11986,7 @@
     "preferred_prefix": "WBls",
     "uri_format": "http://www.wormbase.org/get?name=$1",
     "prefix": "wbls",
-    "all_prefixes": [
+    "synonyms": [
       "wbls"
     ]
   },
@@ -11997,7 +11997,7 @@
     "preferred_prefix": "WBPhenotype",
     "uri_format": "http://www.wormbase.org/get?name=$1",
     "prefix": "wbphenotype",
-    "all_prefixes": [
+    "synonyms": [
       "wbphenotype"
     ]
   },
@@ -12008,7 +12008,7 @@
     "preferred_prefix": "webelements",
     "uri_format": "https://www.webelements.com/$1",
     "prefix": "webelements",
-    "all_prefixes": [
+    "synonyms": [
       "webelements"
     ]
   },
@@ -12018,7 +12018,7 @@
     "preferred_prefix": "wgs84",
     "uri_format": "http://www.w3.org/2003/01/geo/wgs84_pos#$1",
     "prefix": "wgs84",
-    "all_prefixes": [
+    "synonyms": [
       "wgs84"
     ]
   },
@@ -12029,7 +12029,7 @@
     "preferred_prefix": "wikidata",
     "uri_format": "http://www.wikidata.org/entity/$1",
     "prefix": "wikidata",
-    "all_prefixes": [
+    "synonyms": [
       "wd",
       "wd_entity",
       "wikidata"
@@ -12041,7 +12041,7 @@
     "preferred_prefix": "wikidata.property",
     "uri_format": "https://www.wikidata.org/wiki/Property:$1",
     "prefix": "wikidata.property",
-    "all_prefixes": [
+    "synonyms": [
       "wikidata.property"
     ]
   },
@@ -12052,7 +12052,7 @@
     "preferred_prefix": "wikigenes",
     "uri_format": "http://www.wikigenes.org/e/gene/e/$1.html",
     "prefix": "wikigenes",
-    "all_prefixes": [
+    "synonyms": [
       "wikigenes"
     ]
   },
@@ -12063,7 +12063,7 @@
     "preferred_prefix": "wikipathways",
     "uri_format": "http://www.wikipathways.org/instance/$1",
     "prefix": "wikipathways",
-    "all_prefixes": [
+    "synonyms": [
       "wikipathways"
     ]
   },
@@ -12074,7 +12074,7 @@
     "preferred_prefix": "wikipedia.en",
     "uri_format": "http://en.wikipedia.org/wiki/$1",
     "prefix": "wikipedia.en",
-    "all_prefixes": [
+    "synonyms": [
       "wikipedia",
       "wikipedia.en"
     ]
@@ -12086,7 +12086,7 @@
     "preferred_prefix": "worfdb",
     "uri_format": "http://worfdb.dfci.harvard.edu/index.php?search_type=name&page=showresultrc&race_query=$1",
     "prefix": "worfdb",
-    "all_prefixes": [
+    "synonyms": [
       "worfdb"
     ]
   },
@@ -12097,7 +12097,7 @@
     "preferred_prefix": "WormBase",
     "uri_format": "https://www.wormbase.org/get?name=$1",
     "prefix": "wormbase",
-    "all_prefixes": [
+    "synonyms": [
       "wb",
       "wb_ref",
       "wormbase"
@@ -12110,7 +12110,7 @@
     "preferred_prefix": "wormpep",
     "uri_format": "https://www.wormbase.org/db/seq/protein?name=$1",
     "prefix": "wormpep",
-    "all_prefixes": [
+    "synonyms": [
       "wormpep"
     ]
   },
@@ -12121,7 +12121,7 @@
     "preferred_prefix": "worms",
     "uri_format": "http://www.marinespecies.org/aphia.php?p=taxdetails&id=$1",
     "prefix": "worms",
-    "all_prefixes": [
+    "synonyms": [
       "worms"
     ]
   },
@@ -12132,7 +12132,7 @@
     "preferred_prefix": "wwf.ecoregion",
     "uri_format": "https://www.worldwildlife.org/ecoregions/$1",
     "prefix": "wwf.ecoregion",
-    "all_prefixes": [
+    "synonyms": [
       "wwf.ecoregion"
     ]
   },
@@ -12143,7 +12143,7 @@
     "preferred_prefix": "XAO",
     "uri_format": "http://purl.obolibrary.org/obo/XAO_$1",
     "prefix": "xao",
-    "all_prefixes": [
+    "synonyms": [
       "xao"
     ]
   },
@@ -12154,7 +12154,7 @@
     "preferred_prefix": "XCO",
     "uri_format": "http://purl.obolibrary.org/obo/XCO_$1",
     "prefix": "xco",
-    "all_prefixes": [
+    "synonyms": [
       "xco"
     ]
   },
@@ -12165,7 +12165,7 @@
     "preferred_prefix": "xenbase",
     "uri_format": "https://www.xenbase.org/common/xsearch.do?exactSearch=true&searchIn=7&searchValue=$1",
     "prefix": "xenbase",
-    "all_prefixes": [
+    "synonyms": [
       "xenbase"
     ]
   },
@@ -12175,7 +12175,7 @@
     "preferred_prefix": "xl",
     "uri_format": "http://purl.obolibrary.org/obo/XL_$1",
     "prefix": "xl",
-    "all_prefixes": [
+    "synonyms": [
       "xl"
     ]
   },
@@ -12186,7 +12186,7 @@
     "preferred_prefix": "XLMOD",
     "uri_format": "http://purl.obolibrary.org/obo/XLMOD_$1",
     "prefix": "xlmod",
-    "all_prefixes": [
+    "synonyms": [
       "xlmod"
     ]
   },
@@ -12197,7 +12197,7 @@
     "preferred_prefix": "XPO",
     "uri_format": "http://purl.obolibrary.org/obo/XPO_$1",
     "prefix": "xpo",
-    "all_prefixes": [
+    "synonyms": [
       "xpo"
     ]
   },
@@ -12207,7 +12207,7 @@
     "preferred_prefix": "xsd",
     "uri_format": "http://www.w3.org/2001/XMLSchema#$1",
     "prefix": "xsd",
-    "all_prefixes": [
+    "synonyms": [
       "xsd"
     ]
   },
@@ -12218,7 +12218,7 @@
     "preferred_prefix": "ydpm",
     "uri_format": "http://www-deletion.stanford.edu/cgi-bin/YDPM/YDPM_search.cgi?thelist=$1",
     "prefix": "ydpm",
-    "all_prefixes": [
+    "synonyms": [
       "ydpm"
     ]
   },
@@ -12229,7 +12229,7 @@
     "preferred_prefix": "yeastintron",
     "uri_format": "http://intron.ucsc.edu/cgi-bin/yeast4.3/intronreports.pl?outputformat=full&amp;orfName=$1",
     "prefix": "yeastintron",
-    "all_prefixes": [
+    "synonyms": [
       "yeastintron"
     ]
   },
@@ -12240,7 +12240,7 @@
     "preferred_prefix": "yetfasco",
     "uri_format": "http://yetfasco.ccbr.utoronto.ca/showPFM.php?mot=$1",
     "prefix": "yetfasco",
-    "all_prefixes": [
+    "synonyms": [
       "yetfasco"
     ]
   },
@@ -12251,7 +12251,7 @@
     "preferred_prefix": "yid",
     "uri_format": "http://metarray.ucsc.edu/cgi-bin/intron/yirIntrondb?orfName=$1",
     "prefix": "yid",
-    "all_prefixes": [
+    "synonyms": [
       "yid"
     ]
   },
@@ -12262,7 +12262,7 @@
     "preferred_prefix": "ymdb",
     "uri_format": "http://www.ymdb.ca/compounds/$1",
     "prefix": "ymdb",
-    "all_prefixes": [
+    "synonyms": [
       "ymdb"
     ]
   },
@@ -12273,7 +12273,7 @@
     "preferred_prefix": "yrcpdr",
     "uri_format": "http://yeastrc.org/pdr/viewProtein.do?id=$1",
     "prefix": "yrcpdr",
-    "all_prefixes": [
+    "synonyms": [
       "yrcpdr"
     ]
   },
@@ -12283,7 +12283,7 @@
     "preferred_prefix": "ZEA",
     "uri_format": "http://purl.obolibrary.org/obo/ZEA_$1",
     "prefix": "zea",
-    "all_prefixes": [
+    "synonyms": [
       "zea"
     ]
   },
@@ -12294,7 +12294,7 @@
     "preferred_prefix": "ZECO",
     "uri_format": "http://purl.obolibrary.org/obo/ZECO_$1",
     "prefix": "zeco",
-    "all_prefixes": [
+    "synonyms": [
       "zeco"
     ]
   },
@@ -12305,7 +12305,7 @@
     "preferred_prefix": "ZFA",
     "uri_format": "http://purl.obolibrary.org/obo/ZFA_$1",
     "prefix": "zfa",
-    "all_prefixes": [
+    "synonyms": [
       "zfa",
       "zfa_retired"
     ]
@@ -12317,7 +12317,7 @@
     "preferred_prefix": "zfin",
     "uri_format": "http://zfin.org/$1",
     "prefix": "zfin",
-    "all_prefixes": [
+    "synonyms": [
       "zfin"
     ]
   },
@@ -12328,7 +12328,7 @@
     "preferred_prefix": "ZFS",
     "uri_format": "http://purl.obolibrary.org/obo/ZFS_$1",
     "prefix": "zfs",
-    "all_prefixes": [
+    "synonyms": [
       "zfs"
     ]
   },
@@ -12339,7 +12339,7 @@
     "preferred_prefix": "zinc",
     "uri_format": "http://zinc15.docking.org/substances/$1",
     "prefix": "zinc",
-    "all_prefixes": [
+    "synonyms": [
       "zinc"
     ]
   },
@@ -12350,7 +12350,7 @@
     "preferred_prefix": "ZP",
     "uri_format": "http://purl.obolibrary.org/obo/ZP_$1",
     "prefix": "zp",
-    "all_prefixes": [
+    "synonyms": [
       "zp"
     ]
   }

--- a/manubot/cite/tests/test_curie.py
+++ b/manubot/cite/tests/test_curie.py
@@ -1,36 +1,25 @@
 import pytest
 
 from ..citekey import CiteKey
-from ..curie import Handler_CURIE, curie_to_url, get_bioregistry, get_prefix_to_resource
+from ..curie import Handler_CURIE, curie_to_url, manager
 
 
 def test_bioregistry_resource_patterns():
     """
     Can find issues like https://github.com/biopragmatics/bioregistry/issues/242
     """
-    registry = get_bioregistry(compile_patterns=True)
-    assert isinstance(registry, list)
     reports = list()
-    for resource in registry:
-        assert resource["prefix"]  # ensure prefix field exists
-        if "example" in resource and "pattern" in resource:
-            prefix = resource["prefix"]
-            example = resource["example"]
-            handler = Handler_CURIE(prefix)
-            example_curie = CiteKey(f"{prefix}:{example}")
-            report = handler.inspect(example_curie)
-            if report:
-                reports.append(report)
+    for prefix, resource_model in manager.registry.items():
+        example = resource_model.get_example()
+        if example is None:
+            continue
+        handler = Handler_CURIE(prefix)
+        example_curie = CiteKey(f"{prefix}:{example}")
+        report = handler.inspect(example_curie)
+        if report:
+            reports.append(report)
     print("\n".join(reports))
     assert not reports
-
-
-def test_get_prefix_to_resource():
-    prefix_to_resource = get_prefix_to_resource()
-    assert isinstance(prefix_to_resource, dict)
-    assert "doid" in prefix_to_resource
-    resource = prefix_to_resource["doid"]
-    resource["preferred_prefix"] = "DOID"
 
 
 @pytest.mark.parametrize(

--- a/manubot/cite/tests/test_curie.py
+++ b/manubot/cite/tests/test_curie.py
@@ -59,6 +59,8 @@ def test_bioregistry_resource_patterns():
     ],
 )
 def test_curie_to_url(curie, expected):
+    prefix = curie.split(":", )[0]
+    assert manager.get_resource(prefix) is not None, f"Could not look up {prefix}"
     url = curie_to_url(curie)
     assert url == expected
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ install_requires =
     requests-cache
     requests
     toml
+    bioregistry
 
 [options.extras_require]
 webpage =

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ install_requires =
     requests-cache
     requests
     toml
-    bioregistry
+    bioregistry>=0.4.6
 
 [options.extras_require]
 webpage =


### PR DESCRIPTION
This PR is a proof-of-concept that some of the functionalities of CURIE management introduced in #306 could be covered by the Bioregistry. A big caveat of this implementation is that it removes some of the flexibility in handling of CURIEs, but this could also be a potential benefit since improvements meant for Manubot could be just directly PR'd/incorporated into the Bioregistry