### PR TITLE
Add sec to filtered handlers for pandoc-secnos

### DIFF
--- a/manubot/cite/handlers.py
+++ b/manubot/cite/handlers.py
@@ -10,9 +10,9 @@ from .citekey import CiteKey
 
 """
 Non-citation prefixes used by the pandoc-xnos suite of Pandoc filters,
-including pandoc-fignos, pandoc-tablenos, and pandoc-eqnos.
+including pandoc-fignos, pandoc-tablenos, pandoc-eqnos, and pandoc-secnos.
 """
-_pandoc_xnos_prefixes: Set[str] = {"fig", "tbl", "eq"}
+_pandoc_xnos_prefixes: Set[str] = {"fig", "tbl", "eq", "sec"}
 
 
 _local_handlers: List[str] = [

--- a/manubot/cite/tests/test_citations.py
+++ b/manubot/cite/tests/test_citations.py
@@ -10,6 +10,7 @@ def test_citations_filter_pandoc_xnos():
         "fig:pandoc-fignos-key",  # should filter
         "eq:pandoc-eqnos-key",  # should filter
         "tbl:pandoc-tablenos-key",  # should filter
+        "sec:pandoc-secnos-key",  # should filter
         "not-pandoc-xnos-key",  # should keep
     ]
     citations = Citations(input_ids)


### PR DESCRIPTION
This filters out references to `sec:whatever` so that [pandoc-secnos](https://github.com/tomduck/pandoc-secnos) can be used.
