### PR TITLE
Fix test failing on main. 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+default_language_version:
+  python: python3.10
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.2.0

--- a/manubot/cite/tests/test_wikidata.py
+++ b/manubot/cite/tests/test_wikidata.py
@@ -34,6 +34,6 @@ def test_get_wikidata_csl_item_author_ordering():
         "Levernier",
         "Munro",
         "McLaughlin",
-        "Greshake",  # actually should be Greshake Tzovaras
+        "Tzovaras",
         "Greene",
     ]


### PR DESCRIPTION
It seems that this information was corrected on the queried source.

The comment states that this test should give another value,
so we use that value and the test passes again.

The order of the authors is unaffected and that seems to be the tested parameter.

Before this change is applied, this test fails on main branch.