### PR TITLE
#337 Set default timeout on ISBN search.

### DIFF
--- a/manubot/cite/isbn.py
+++ b/manubot/cite/isbn.py
@@ -4,6 +4,8 @@ import re
 
 from .handlers import Handler
 
+default_timeout = 3
+
 
 class Handler_ISBN(Handler):
 
@@ -15,6 +17,9 @@ class Handler_ISBN(Handler):
 
     def inspect(self, citekey):
         import isbnlib
+
+        isbnlib.config.setthreadstimeout(seconds=timeout_seconds)
+        isbnlib.config.seturlopentimeout(seconds=timeout_seconds)
 
         fail = isbnlib.notisbn(citekey.accession, level="strict")
         if fail:
@@ -40,6 +45,9 @@ def get_isbn_csl_item(isbn: str):
     non-failing method.
     """
     import isbnlib
+
+    isbnlib.config.setthreadstimeout(seconds=timeout_seconds)
+    isbnlib.config.seturlopentimeout(seconds=timeout_seconds)
 
     isbn = isbnlib.to_isbn13(isbn)
     for retriever in isbn_retrievers:
@@ -130,6 +138,9 @@ def get_isbn_csl_item_isbnlib(isbn: str):
     Generate CSL JSON Data for an ISBN using isbnlib.
     """
     import isbnlib
+
+    isbnlib.config.setthreadstimeout(seconds=timeout_seconds)
+    isbnlib.config.seturlopentimeout(seconds=timeout_seconds)
 
     metadata = isbnlib.meta(isbn)
     csl_json = isbnlib.registry.bibformatters["csl"](metadata)

--- a/manubot/cite/isbn.py
+++ b/manubot/cite/isbn.py
@@ -7,6 +7,14 @@ from .handlers import Handler
 default_timeout = 3
 
 
+def set_isbnlib_timeout(seconds=default_timeout):
+    import isbnlib
+
+    isbnlib.config.setthreadstimeout(seconds=seconds)
+    isbnlib.config.seturlopentimeout(seconds=seconds)
+    return isbnlib
+
+
 class Handler_ISBN(Handler):
 
     standard_prefix = "isbn"
@@ -16,11 +24,7 @@ class Handler_ISBN(Handler):
     ]
 
     def inspect(self, citekey):
-        import isbnlib
-
-        isbnlib.config.setthreadstimeout(seconds=timeout_seconds)
-        isbnlib.config.seturlopentimeout(seconds=timeout_seconds)
-
+        isbnlib = set_isbnlib_timeout()
         fail = isbnlib.notisbn(citekey.accession, level="strict")
         if fail:
             return f"identifier violates the ISBN syntax according to isbnlib v{isbnlib.__version__}"
@@ -44,10 +48,7 @@ def get_isbn_csl_item(isbn: str):
     in order, with this function returning the metadata from the first
     non-failing method.
     """
-    import isbnlib
-
-    isbnlib.config.setthreadstimeout(seconds=timeout_seconds)
-    isbnlib.config.seturlopentimeout(seconds=timeout_seconds)
+    isbnlib = set_isbnlib_timeout()
 
     isbn = isbnlib.to_isbn13(isbn)
     for retriever in isbn_retrievers:
@@ -137,11 +138,7 @@ def get_isbn_csl_item_isbnlib(isbn: str):
     """
     Generate CSL JSON Data for an ISBN using isbnlib.
     """
-    import isbnlib
-
-    isbnlib.config.setthreadstimeout(seconds=timeout_seconds)
-    isbnlib.config.seturlopentimeout(seconds=timeout_seconds)
-
+    isbnlib = set_isbnlib_timeout()
     metadata = isbnlib.meta(isbn)
     csl_json = isbnlib.registry.bibformatters["csl"](metadata)
     csl_data = json.loads(csl_json)


### PR DESCRIPTION
I've reduced the scope of changes on #338 [as requested](https://github.com/manubot/manubot/pull/338#issuecomment-1183912661):

> So in the interest of quickly merging, can we reduce this PR (or a new one) to just address the requests that are known to timeout?
>
> _Originally posted by @dhimmel in https://github.com/manubot/manubot/issues/338#issuecomment-1183912661_**

This change is only configurable on source code in the global variable defined on isbn search file.