### PR TITLE
Swap first and last name in Citoid ISBN metadata

### DIFF
--- a/manubot/cite/isbn.py
+++ b/manubot/cite/isbn.py
@@ -100,7 +100,7 @@ def get_isbn_csl_item_citoid(isbn: str):
         csl_item["title"] = mediawiki["title"]
     if "author" in mediawiki:
         csl_author = list()
-        for last, first in mediawiki["author"]:
+        for first, last in mediawiki["author"]:
             csl_author.append({"given": first, "family": last})
         if csl_author:
             csl_item["author"] = csl_author

--- a/manubot/cite/tests/test_isbn.py
+++ b/manubot/cite/tests/test_isbn.py
@@ -42,3 +42,14 @@ def test_get_isbn_csl_item_zotero_with_note_issue():
     isbn = "9780262517638"
     csl_item = get_isbn_csl_item_zotero(isbn)
     assert csl_item["author"][0]["family"] == "Suber"
+
+
+def test_get_isbn_csl_item_citoid_author_order():
+    """
+    Confirm author order is parsed correctly
+    https://en.wikipedia.org/api/rest_v1/data/citation/mediawiki/9781801819312
+    https://www.mediawiki.org/wiki/Citoid/API#mediawiki
+    """
+    csl_item = get_isbn_csl_item_citoid("9781801819312")
+    assert csl_item["author"][0]["given"] == "Sebastian"
+    assert csl_item["author"][0]["family"] == "Raschka"


### PR DESCRIPTION
Closes #344

Note that this does not address the other possible issue with Citoid I mentioned here https://github.com/manubot/manubot/issues/344#issuecomment-1264676759
> when there are multiple authors, only the first is listed as an author. The rest are contributors.

I think that problem is with the upstream data, not Manubot.