### PR TITLE
manuscript metadata: explicit date

### DIFF
--- a/manubot/process/header-includes-template.html
+++ b/manubot/process/header-includes-template.html
@@ -15,9 +15,9 @@ Suggest improvements at https://github.com/manubot/manubot/blob/main/manubot/pro
 <meta name="citation_publication_date" content="{{ pandoc['date-meta'] }}" />
 <meta property="article:published_time" content="{{ pandoc['date-meta'] }}" />
 {% endif -%}
-{% if manubot.generated_iso is defined -%}
-<meta name="dc.modified" content="{{ manubot.generated_iso }}" />
-<meta property="article:modified_time" content="{{ manubot.generated_iso }}" />
+{% if manubot.generated is defined -%}
+<meta name="dc.modified" content="{{ manubot.generated }}" />
+<meta property="article:modified_time" content="{{ manubot.generated }}" />
 {% endif -%}
 {% if pandoc.lang is defined -%}
 <meta name="dc.language" content="{{ pandoc.lang }}" />

--- a/manubot/process/header-includes-template.html
+++ b/manubot/process/header-includes-template.html
@@ -3,6 +3,7 @@ Manubot generated metadata rendered from header-includes-template.html.
 Suggest improvements at https://github.com/manubot/manubot/blob/main/manubot/process/header-includes-template.html
 -->
 <meta name="dc.format" content="text/html" />
+<meta property="og:type" content="article" />
 {% if pandoc.title is defined -%}
 <meta name="dc.title" content="{{ pandoc.title|escape }}" />
 <meta name="citation_title" content="{{ pandoc.title|escape }}" />
@@ -12,6 +13,11 @@ Suggest improvements at https://github.com/manubot/manubot/blob/main/manubot/pro
 {% if pandoc['date-meta'] is defined -%}
 <meta name="dc.date" content="{{ pandoc['date-meta'] }}" />
 <meta name="citation_publication_date" content="{{ pandoc['date-meta'] }}" />
+<meta property="article:published_time" content="{{ pandoc['date-meta'] }}" />
+{% endif -%}
+{% if manubot.generated_iso is defined -%}
+<meta name="dc.modified" content="{{ manubot.generated_iso }}" />
+<meta property="article:modified_time" content="{{ manubot.generated_iso }}" />
 {% endif -%}
 {% if pandoc.lang is defined -%}
 <meta name="dc.language" content="{{ pandoc.lang }}" />

--- a/manubot/process/tests/manuscripts/example/content/metadata.yaml
+++ b/manubot/process/tests/manuscripts/example/content/metadata.yaml
@@ -2,6 +2,7 @@
 title: "Example manuscript for testing"
 keywords:
   - manubot
+date: 2022-11-22
 authors:
   -
     github: dhimmel

--- a/manubot/process/util.py
+++ b/manubot/process/util.py
@@ -193,7 +193,7 @@ def load_variables(args) -> dict:
             variables["pandoc"][key] = metadata.pop(key)
 
     # Add date & generated timestamp to metadata
-    manuscript_date = metadata.pop("date")
+    manuscript_date = metadata.pop("date", None)
     if isinstance(manuscript_date, str):
         manuscript_date = date.fromisoformat(manuscript_date)
     now = datetime_now()
@@ -205,10 +205,11 @@ def load_variables(args) -> dict:
             f"(in the {now:%Z} timezone)"
         )
     variables["pandoc"]["date-meta"] = manuscript_date.isoformat()
+    variables["manubot"]["date"] = manuscript_date.isoformat()
     variables["manubot"][
-        "date"
+        "date_long"
     ] = f"{manuscript_date:%B} {manuscript_date.day}, {manuscript_date.year}"
-    variables["manubot"]["generated_iso"] = now.isoformat(timespec="seconds")
+    variables["manubot"]["generated"] = now.isoformat(timespec="seconds")
     variables["manubot"]["generated_date_long"] = f"{now:%B} {now.day}, {now.year}"
 
     # Process authors metadata


### PR DESCRIPTION
helpful for https://github.com/manubot/rootstock/issues/283

Previously there was only a single date written to `variables.json` (the output manuscript metadata) and that was based on the generated timestamp of the manuscript.

Here we add support for a field in `metadata.yaml` named `date` to set an explicit publication date. The generated timestamp is still retained in the metadata and used to set some additional modified tags in the HTML header. This could be useful when you want to keep a fixed publication date on a manuscript but want to rebuild it to say fix a formatting issue or add new Manubot features.