### PR TITLE
get_pubmed_csl_item: use rettype=xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Create a development environment using:
 
 ```shell
 conda create --name manubot-dev --channel conda-forge \
-  python=3.11 pandoc=2.8
+  python=3.11 pandoc=2.11.3.1
 conda activate manubot-dev  # assumes conda >= 4.4
 pip install --editable ".[webpage,dev]"
 ```

--- a/manubot/cite/pubmed.py
+++ b/manubot/cite/pubmed.py
@@ -129,7 +129,7 @@ def get_pubmed_csl_item(pmid: Union[str, int]) -> Dict[str, Any]:
     https://github.com/ncbi/citation-exporter/issues/3#issuecomment-355313143
     """
     pmid = str(pmid)
-    params = {"db": "pubmed", "id": pmid, "rettype": "full"}
+    params = {"db": "pubmed", "id": pmid, "retmode": "xml"}
     headers = {"User-Agent": get_manubot_user_agent()}
     url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
     with _get_eutils_rate_limiter():

--- a/manubot/pandoc/tests/test_cite_filter/output.txt
+++ b/manubot/pandoc/tests/test_cite_filter/output.txt
@@ -29,7 +29,7 @@ GitHub https://github.com/manubot/manubot/pull/189
 
 4. Basic local alignment search tool
 Stephen F Altschul, Warren Gish, Webb Miller, Eugene W Myers, David J Lipman Journal of Molecular Biology (1990-10) https://doi.org/cnsjsz
-DOI: 10.1016/s0022-2836(05)80360-2
+DOI: 10.1016/s0022-2836(05)80360-2 · pmid: 2231712
 
 5. Semi-supervised Knowledge Transfer for Deep Learning from Private Training Data
 Nicolas Papernot, Martín Abadi, Úlfar Erlingsson, Ian Goodfellow, Kunal Talwar (2022-07-21) https://openreview.net/forum?id=HkwoSDPgg


### PR DESCRIPTION
closes https://github.com/manubot/manubot/issues/354

`rettype=full` is no longer supported.