### PR TITLE
Replace pre-commit checks with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
   python: python3.11
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       # Check for files that contain merge conflict strings.
       - id: check-merge-conflict
@@ -23,7 +23,7 @@ repos:
         args:
         - --fix
   - repo: https://github.com/python/black
-    rev: 22.10.0
+    rev: 22.12.0
     hooks:
       - id: black
         language_version: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,22 +16,14 @@ repos:
       - id: check-toml
       # This hook checks yaml files for parseable syntax.
       - id: check-yaml
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.2.2
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.229
     hooks:
-      - id: pyupgrade
-        args: [--py37-plus]
-  - repo: https://github.com/timothycrosley/isort
-    rev: 5.10.1
-    hooks:
-      - id: isort
+      - id: ruff
+        args:
+        - --fix
   - repo: https://github.com/python/black
     rev: 22.10.0
     hooks:
       - id: black
-        language_version: python3
-  - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
-    hooks:
-      - id: flake8
         language_version: python3

--- a/conftest.py
+++ b/conftest.py
@@ -1,11 +1,11 @@
 import pytest
 
-markers = dict(
-    integration="marks integration tests that cover large portions of the codebase and their interactions",
-    appveyor="marks tests where execution on AppVeyor provides additional coverage beyond GitHub Actions",
-    travis="marks tests where execution on Travis CI provides additional coverage beyond GitHub Actions",
-    pandoc_version_sensitive="marks tests that require a specific version of pandoc to pass",
-)
+markers = {
+    "integration": "marks integration tests that cover large portions of the codebase and their interactions",
+    "appveyor": "marks tests where execution on AppVeyor provides additional coverage beyond GitHub Actions",
+    "travis": "marks tests where execution on Travis CI provides additional coverage beyond GitHub Actions",
+    "pandoc_version_sensitive": "marks tests that require a specific version of pandoc to pass",
+}
 
 
 def pytest_configure(config):

--- a/manubot/cite/arxiv.py
+++ b/manubot/cite/arxiv.py
@@ -132,7 +132,7 @@ def get_arxiv_csl_item_export_api(arxiv_id):
     csl_item.set_date(published, variable="issued")
 
     # Extract authors
-    authors = list()
+    authors = []
     for elem in entry.findall(prefix + "author"):
         name = elem.findtext(prefix + "name")
         author = {"literal": name}
@@ -203,7 +203,7 @@ def get_arxiv_csl_item_oai(arxiv_id):
 
     # Extract authors
     author_elems = arxiv_elem.findall(f"{ns_arxiv}authors/{ns_arxiv}author")
-    authors = list()
+    authors = []
     for author_elem in author_elems:
         author = {}
         given = author_elem.findtext(f"{ns_arxiv}forenames")

--- a/manubot/cite/citations.py
+++ b/manubot/cite/citations.py
@@ -74,10 +74,10 @@ class Citations:
         def get_key(x):
             return getattr(x, attribute)
 
-        key_to_indices = dict()
+        key_to_indices = {}
         for i, citekey in enumerate(self.citekeys):
             key = get_key(citekey)
-            key_to_indices.setdefault(key, list()).append(i)
+            key_to_indices.setdefault(key, []).append(i)
         items = list(key_to_indices.items())
         if sort:
             items.sort(key=lambda item: item[0])

--- a/manubot/cite/cite_command.py
+++ b/manubot/cite/cite_command.py
@@ -124,7 +124,7 @@ def _exit_without_pandoc() -> None:
     if get_pandoc_info()["pandoc"]:
         return
     logging.critical(
-        f"pandoc command not found on system. Ensure that Pandoc is installed."
+        "pandoc command not found on system. Ensure that Pandoc is installed."
     )
     raise SystemExit(1)
 
@@ -136,7 +136,7 @@ def _check_pandoc_version(info, metadata, format):
     Please add additional minimum version information to this function, as its
     discovered.
     """
-    issues = list()
+    issues = []
     if format == "jats" and info["pandoc version"] < (2,):
         issues.append("--jats requires pandoc >= v2.0.")
     # --csl=URL did not work in https://travis-ci.org/greenelab/manubot/builds/417314743#L796,

--- a/manubot/cite/citekey.py
+++ b/manubot/cite/citekey.py
@@ -249,12 +249,15 @@ def shorten_citekey(standard_citekey: str) -> str:
 
 
 def citekey_to_csl_item(
-    citekey, prune=True, manual_refs={}, log_level: tp.Union[str, int] = "WARNING"
+    citekey, prune=True, manual_refs=None, log_level: tp.Union[str, int] = "WARNING"
 ):
     """
     Generate a CSL_Item for the input citekey.
     """
     from manubot import __version__ as manubot_version
+
+    if manual_refs is None:
+        manual_refs = {}
 
     # https://stackoverflow.com/a/35704430/4651668
     log_level = logging._checkLevel(log_level)

--- a/manubot/cite/csl_item.py
+++ b/manubot/cite/csl_item.py
@@ -78,7 +78,7 @@ class CSL_Item(dict):
         but constructing small CSL_Item objects is useful for testing.
         """
         if dictionary is None:
-            dictionary = dict()
+            dictionary = {}
         super().__init__(copy.deepcopy(dictionary))
         self.update(copy.deepcopy(kwargs))
 
@@ -330,7 +330,7 @@ def date_to_date_parts(
         f"{re_year}-{re_month}-{re_day}",
         f"{re_year}-{re_month}",
         f"{re_year}",
-        f".*",  # regex to match anything
+        ".*",  # regex to match anything
     ]
     for pattern in patterns:
         match = re.match(pattern, date)
@@ -363,7 +363,7 @@ def date_parts_to_string(date_parts, fill: bool = False) -> Optional[str]:
     if not date_parts:
         return None
     if not isinstance(date_parts, (tuple, list)):
-        raise ValueError(f"date_parts must be a tuple or list")
+        raise ValueError("date_parts must be a tuple or list")
     while fill and 1 <= len(date_parts) < 3:
         date_parts.append(1)
     widths = 4, 2, 2

--- a/manubot/cite/curie/__init__.py
+++ b/manubot/cite/curie/__init__.py
@@ -69,8 +69,8 @@ class Handler_CURIE(Handler):
     def __post_init__(self):
         try:
             self.resource = get_prefix_to_resource()[self.prefix_lower]
-        except KeyError:
-            raise ValueError(f"Unrecognized CURIE prefix {self.prefix_lower}")
+        except KeyError as err:
+            raise ValueError(f"Unrecognized CURIE prefix {self.prefix_lower}") from err
         self.standard_prefix = (
             self.resource.get("preferred_prefix") or self.resource["prefix"]
         )
@@ -115,7 +115,7 @@ def _download_bioregistry() -> None:
     response.raise_for_status()
     results = response.json()
     assert isinstance(results, dict)
-    registry = list()
+    registry = []
     for prefix, resource in results.items():
         assert isinstance(resource, dict)
         if not resource.get("uri_format"):
@@ -150,7 +150,7 @@ def get_bioregistry(compile_patterns=False) -> dict:
 
 @functools.lru_cache()
 def get_prefix_to_resource() -> typing.Dict[str, typing.Dict]:
-    prefix_to_resource = dict()
+    prefix_to_resource = {}
     for resource in get_bioregistry():
         for prefix in resource["all_prefixes"]:
             prefix_to_resource[prefix] = resource
@@ -169,10 +169,10 @@ def standardize_curie(curie: str) -> str:
         )
     try:
         prefix, accession = curie.split(":", 1)
-    except ValueError:
+    except ValueError as err:
         raise ValueError(
             f"curie must be splittable by `:` and formatted like `prefix:accession`. Received {curie}"
-        )
+        ) from err
     handler = Handler_CURIE(prefix.lower())
     return f"{handler.standard_prefix}:{accession}"
 

--- a/manubot/cite/isbn.py
+++ b/manubot/cite/isbn.py
@@ -94,12 +94,12 @@ def get_isbn_csl_item_citoid(isbn: str):
                 f"{json.dumps(result.text)}"
             )
     (mediawiki,) = result
-    csl_item = dict()
+    csl_item = {}
     csl_item["type"] = mediawiki.get("itemType", "book")
     if "title" in mediawiki:
         csl_item["title"] = mediawiki["title"]
     if "author" in mediawiki:
-        csl_author = list()
+        csl_author = []
         for first, last in mediawiki["author"]:
             csl_author.append({"given": first, "family": last})
         if csl_author:

--- a/manubot/cite/pubmed.py
+++ b/manubot/cite/pubmed.py
@@ -91,13 +91,13 @@ def _get_literature_citation_exporter_csl_item(
             f"Error calling _get_literature_citation_exporter_csl_item.\n"
             f'database must be either "pubmed" or "pmc", not {database}'
         )
-        assert False
+        raise AssertionError()
     if not identifier:
         logging.error(
-            f"Error calling _get_literature_citation_exporter_csl_item.\n"
-            f"identifier cannot be blank"
+            "Error calling _get_literature_citation_exporter_csl_item.\n"
+            "identifier cannot be blank"
         )
-        assert False
+        raise AssertionError()
     params = {"format": "csl", "id": identifier}
     headers = {"User-Agent": get_manubot_user_agent()}
     url = f"https://api.ncbi.nlm.nih.gov/lit/ctxp/v1/{database}/"
@@ -117,7 +117,7 @@ def _get_literature_citation_exporter_csl_item(
             f"Literature Citation Exporter returned JSON indicating an error for {response.url}\n"
             f"{json.dumps(csl_item, indent=2)}"
         )
-        assert False
+        raise AssertionError()
     return csl_item
 
 
@@ -165,7 +165,7 @@ def csl_item_from_pubmed_article(article: ElementTree.Element) -> Dict[str, Any]
             f"Expected article to be an XML element with tag PubmedArticle, received tag {article.tag!r}"
         )
 
-    csl_item = dict()
+    csl_item = {}
 
     if not article.find("MedlineCitation/Article"):
         raise NotImplementedError("Unsupported PubMed record: no <Article> element")
@@ -202,10 +202,10 @@ def csl_item_from_pubmed_article(article: ElementTree.Element) -> Dict[str, Any]
     if date_parts:
         csl_item["issued"] = {"date-parts": [date_parts]}
 
-    authors_csl = list()
+    authors_csl = []
     authors = article.findall("MedlineCitation/Article/AuthorList/Author")
     for author in authors:
-        author_csl = dict()
+        author_csl = {}
         given = author.findtext("ForeName")
         if given:
             author_csl["given"] = given

--- a/manubot/cite/tests/test_cite_command.py
+++ b/manubot/cite/tests/test_cite_command.py
@@ -161,7 +161,7 @@ def test_cite_command_render_stdout(args, filename):
             "Writing output to file such that future tests will pass."
         )
         path.write_text(process.stdout, encoding="utf-8")
-        assert False
+        raise AssertionError()
     expected = path.read_text(encoding="utf-8-sig")
     assert process.stdout == expected
 

--- a/manubot/cite/tests/test_citekey.py
+++ b/manubot/cite/tests/test_citekey.py
@@ -9,89 +9,89 @@ from manubot.cite.citekey import CiteKey, shorten_citekey, url_to_citekey
     [
         pytest.param(
             "DOI:10.5061/DRYad.q447c/1",
-            dict(
-                prefix="DOI",
-                prefix_lower="doi",
-                standard_accession="10.5061/dryad.q447c/1",
-                standard_id="doi:10.5061/dryad.q447c/1",
-            ),
+            {
+                "prefix": "DOI",
+                "prefix_lower": "doi",
+                "standard_accession": "10.5061/dryad.q447c/1",
+                "standard_id": "doi:10.5061/dryad.q447c/1",
+            },
             id="doi",
         ),
         pytest.param(
             "10.5061/DRYad.q447c/1",
-            dict(
-                prefix="doi",
-                prefix_lower="doi",
-                standard_prefix="doi",
-                standard_accession="10.5061/dryad.q447c/1",
-                standard_id="doi:10.5061/dryad.q447c/1",
-            ),
+            {
+                "prefix": "doi",
+                "prefix_lower": "doi",
+                "standard_prefix": "doi",
+                "standard_accession": "10.5061/dryad.q447c/1",
+                "standard_id": "doi:10.5061/dryad.q447c/1",
+            },
             id="doi-infer-prefix",
         ),
         pytest.param(
             "arXiv:1407.3561v1",
-            dict(
-                prefix="arXiv",
-                prefix_lower="arxiv",
-                standard_prefix="arxiv",
-                standard_accession="1407.3561v1",
-                standard_id="arxiv:1407.3561v1",
-            ),
+            {
+                "prefix": "arXiv",
+                "prefix_lower": "arxiv",
+                "standard_prefix": "arxiv",
+                "standard_accession": "1407.3561v1",
+                "standard_id": "arxiv:1407.3561v1",
+            },
             id="arxiv",
         ),
         pytest.param(
             "pmid:24159271",
-            dict(
-                standard_id="pubmed:24159271",
-            ),
+            {
+                "standard_id": "pubmed:24159271",
+            },
             id="pmid",
         ),
         pytest.param(
             "pmcid:PMC4304851",
-            dict(
-                prefix="pmcid",
-                prefix_lower="pmcid",
-                standard_prefix="pmc",
-                standard_id="pmc:PMC4304851",
-            ),
+            {
+                "prefix": "pmcid",
+                "prefix_lower": "pmcid",
+                "standard_prefix": "pmc",
+                "standard_id": "pmc:PMC4304851",
+            },
             id="pmcid",
         ),
         pytest.param(
             "https://greenelab.github.io/manubot-rootstock/",
-            dict(
-                prefix="https",
-                prefix_lower="https",
-                standard_prefix="url",
-                standard_id="url:https://greenelab.github.io/manubot-rootstock/",
-            ),
+            {
+                "prefix": "https",
+                "prefix_lower": "https",
+                "standard_prefix": "url",
+                "standard_id": "url:https://greenelab.github.io/manubot-rootstock/",
+            },
             id="https",
         ),
         pytest.param(
             "isbn:1-339-91988-5",
-            dict(
-                standard_id="isbn:9781339919881",
-            ),
+            {
+                "standard_id": "isbn:9781339919881",
+            },
             id="isbn",
         ),
         pytest.param(
             "DOID:14330",
-            dict(
-                standard_id="DOID:14330",
-            ),
+            {
+                "standard_id": "DOID:14330",
+            },
             id="doid",
         ),
         pytest.param(
             "PubChem.substance:100101",
-            dict(
-                standard_id="pubchem.substance:100101",
-            ),
+            {
+                "standard_id": "pubchem.substance:100101",
+            },
             id="PubChem.substance",
         ),
         pytest.param(
             "Wikidata:Q50051684",
-            dict(
-                standard_id="wikidata:Q50051684",
-            ),
+            {
+                "standard_id": "wikidata:Q50051684",
+            },
             id="wikidata",
         ),
     ],

--- a/manubot/cite/tests/test_citekey_api.py
+++ b/manubot/cite/tests/test_citekey_api.py
@@ -97,7 +97,7 @@ def test_citekey_to_csl_item_pmc():
     """
     https://api.ncbi.nlm.nih.gov/lit/ctxp/v1/pmc/?format=csl&id=3041534
     """
-    citekey = f"pmc:PMC3041534"
+    citekey = "pmc:PMC3041534"
     csl_item = citekey_to_csl_item(citekey)
     assert csl_item["id"] == "1CGP1eifE"
     assert csl_item["URL"] == "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3041534/"

--- a/manubot/cite/tests/test_curie.py
+++ b/manubot/cite/tests/test_curie.py
@@ -1,7 +1,12 @@
 import pytest
 
 from ..citekey import CiteKey
-from ..curie import Handler_CURIE, curie_to_url, get_bioregistry, get_prefix_to_resource
+from ..curie import (
+    Handler_CURIE,
+    curie_to_url,
+    get_bioregistry,
+    get_prefix_to_resource,
+)
 
 
 def test_bioregistry_resource_patterns():
@@ -10,7 +15,7 @@ def test_bioregistry_resource_patterns():
     """
     registry = get_bioregistry(compile_patterns=True)
     assert isinstance(registry, list)
-    reports = list()
+    reports = []
     for resource in registry:
         assert resource["prefix"]  # ensure prefix field exists
         if "example" in resource and "pattern" in resource:

--- a/manubot/cite/tests/test_doi.py
+++ b/manubot/cite/tests/test_doi.py
@@ -28,7 +28,7 @@ def test_get_doi_csl_item_default():
     doi = "10.1101/142760"
     csl_item = get_doi_csl_item_default(doi)
     assert isinstance(csl_item, dict)
-    csl_item["publisher"] == "Cold Spring Harbor Laboratory"
+    assert csl_item["publisher"] == "Cold Spring Harbor Laboratory"
 
 
 def test_get_doi_csl_item_zotero():
@@ -42,7 +42,7 @@ def test_get_doi_csl_item_zotero():
     doi = "10.1038/ng.3834"
     csl_item = get_doi_csl_item_zotero(doi)
     assert isinstance(csl_item, dict)
-    csl_item["author"][9]["family"] == "GTEx Consortium"
+    assert csl_item["author"][9]["family"] == "GTEx Consortium"
 
 
 def test_get_doi_csl_item():

--- a/manubot/cite/tests/test_doi.py
+++ b/manubot/cite/tests/test_doi.py
@@ -42,7 +42,9 @@ def test_get_doi_csl_item_zotero():
     doi = "10.1038/ng.3834"
     csl_item = get_doi_csl_item_zotero(doi)
     assert isinstance(csl_item, dict)
-    assert csl_item["author"][9]["family"] == "GTEx Consortium"
+    # for an unknown reason, GTEx Consortium becomes the first author
+    # which differs from the publisher HTML and Crossref metadata ordering.
+    assert csl_item["author"][0]["family"] == "GTEx Consortium"
 
 
 def test_get_doi_csl_item():

--- a/manubot/pandoc/cite_filter.py
+++ b/manubot/pandoc/cite_filter.py
@@ -203,10 +203,10 @@ def _get_load_manual_references_kwargs(doc: pf.Doc) -> Dict[str, Any]:
         and os.path.exists(bibliography_cache_path)
     ):
         bibliography_paths.append(bibliography_cache_path)
-    return dict(
-        paths=bibliography_paths,
-        extra_csl_items=manual_refs,
-    )
+    return {
+        "paths": bibliography_paths,
+        "extra_csl_items": manual_refs,
+    }
 
 
 def process_citations(doc: pf.Doc) -> None:
@@ -230,7 +230,7 @@ def process_citations(doc: pf.Doc) -> None:
             f"Expected metadata.citekey-aliases to be a dict, "
             f"but received a {citekey_aliases.__class__.__name__}. Disregarding."
         )
-        citekey_aliases = dict()
+        citekey_aliases = {}
     doc.manubot["citekey_aliases"] = citekey_aliases
     doc.walk(_get_reference_link_citekey_aliases)
     doc.walk(_get_citekeys_action)
@@ -275,7 +275,10 @@ def process_citations(doc: pf.Doc) -> None:
 
 
 def main() -> None:
-    from manubot.command import exit_if_error_handler_fired, setup_logging_and_errors
+    from manubot.command import (
+        exit_if_error_handler_fired,
+        setup_logging_and_errors,
+    )
 
     diagnostics = setup_logging_and_errors()
     args = parse_args()

--- a/manubot/pandoc/util.py
+++ b/manubot/pandoc/util.py
@@ -58,7 +58,7 @@ def get_command_info(command: str) -> dict:
     Returns a dictionary containing some information about a command
     """
 
-    command_info_dict = dict()
+    command_info_dict = {}
 
     path = shutil.which(command)
     command_info_dict[command] = bool(path)

--- a/manubot/process/bibliography.py
+++ b/manubot/process/bibliography.py
@@ -41,7 +41,7 @@ def load_bibliography(path: str) -> list:
     return csl_items
 
 
-def load_manual_references(paths=[], extra_csl_items=[]) -> dict:
+def load_manual_references(paths=None, extra_csl_items=None) -> dict:
     """
     Read manual references from bibliography text files specified by a list of paths.
     Returns a standard_citation to CSL Item dictionary.
@@ -52,6 +52,11 @@ def load_manual_references(paths=[], extra_csl_items=[]) -> dict:
     precedence is given to reference defined last.
     References in `extra_csl_items` take precedence over those from `paths`.
     """
+    if paths is None:
+        paths = []
+    if extra_csl_items is None:
+        extra_csl_items = []
+
     from manubot.cite.csl_item import CSL_Item
 
     csl_items = []
@@ -62,12 +67,12 @@ def load_manual_references(paths=[], extra_csl_items=[]) -> dict:
         bibliography = load_bibliography(path)
         for csl_item in bibliography:
             csl_item.note_append_text(
-                f"Loaded from an external bibliography file by Manubot."
+                "Loaded from an external bibliography file by Manubot."
             )
             csl_item.note_append_dict({"source_bibliography": path_obj.name})
             csl_items.append(csl_item)
     csl_items.extend(map(CSL_Item, extra_csl_items))
-    manual_refs = dict()
+    manual_refs = {}
     for csl_item in csl_items:
         try:
             csl_item.standardize_id()

--- a/manubot/process/manuscript.py
+++ b/manubot/process/manuscript.py
@@ -11,7 +11,7 @@ def get_text(directory):
     """
     section_dir = pathlib.Path(directory)
     paths = sorted(section_dir.glob("[0-9]*.md"))
-    name_to_text = dict()
+    name_to_text = {}
     for path in paths:
         name_to_text[path.stem] = path.read_text(encoding="utf-8-sig")
     logging.info("Manuscript content parts:\n" + "\n".join(name_to_text))
@@ -22,7 +22,7 @@ def get_manuscript_stats(text):
     """
     Compute manuscript statistics.
     """
-    stats = dict()
+    stats = {}
     stats["word_count"] = len(text.split())
     logging.info(f"Generated manscript stats:\n{json.dumps(stats, indent=2)}")
     return stats

--- a/manubot/process/metadata.py
+++ b/manubot/process/metadata.py
@@ -20,7 +20,7 @@ def get_header_includes(variables: dict) -> str:
         template = path.read_text(encoding="utf-8-sig")
         return template_with_jinja2(template, variables)
     except Exception:
-        logging.exception(f"Error generating header-includes.")
+        logging.exception("Error generating header-includes.")
         return ""
 
 
@@ -148,7 +148,7 @@ def get_manuscript_urls(html_url: Optional[str] = None) -> dict:
 
     from .ci import get_continuous_integration_parameters
 
-    urls = dict()
+    urls = {}
     ci_params = get_continuous_integration_parameters()
     if html_url is None:
         if not ci_params:

--- a/manubot/process/tests/manuscripts/citation-rendering/content/generate-csl-json-combinations.py
+++ b/manubot/process/tests/manuscripts/citation-rendering/content/generate-csl-json-combinations.py
@@ -60,7 +60,7 @@ csl_key_subset = [
 combinations = list(powerset(csl_key_subset))
 print(f"generated {len(combinations)} combinations of CSL JSON keys")
 
-csl_data = list()
+csl_data = []
 citation_list_md = ""
 for i, keys in enumerate(combinations):
     citation_id = "raw:" + "_".join(keys) if keys else "raw:blank"

--- a/manubot/process/tests/test_metadata.py
+++ b/manubot/process/tests/test_metadata.py
@@ -3,7 +3,11 @@ import copy
 import pytest
 
 from ..ci import get_continuous_integration_parameters
-from ..metadata import get_header_includes, get_manuscript_urls, get_thumbnail_url
+from ..metadata import (
+    get_header_includes,
+    get_manuscript_urls,
+    get_thumbnail_url,
+)
 
 
 def test_get_header_includes_description_abstract():

--- a/manubot/process/util.py
+++ b/manubot/process/util.py
@@ -10,7 +10,11 @@ from typing import List, Optional
 import jinja2
 
 from manubot.process.ci import get_continuous_integration_parameters
-from manubot.process.manuscript import datetime_now, get_manuscript_stats, get_text
+from manubot.process.manuscript import (
+    datetime_now,
+    get_manuscript_stats,
+    get_text,
+)
 from manubot.process.metadata import (
     get_head_commit,
     get_header_includes,
@@ -18,7 +22,11 @@ from manubot.process.metadata import (
     get_software_versions,
     get_thumbnail_url,
 )
-from manubot.util import get_configured_yaml, read_serialized_data, read_serialized_dict
+from manubot.util import (
+    get_configured_yaml,
+    read_serialized_data,
+    read_serialized_dict,
+)
 
 
 def read_variable_files(paths: List[str], variables: Optional[dict] = None) -> dict:
@@ -126,7 +134,7 @@ def add_author_affiliations(variables: dict) -> dict:
     affiliations to the top-level of variables. If no authors have any
     affiliations, variables is left unmodified.
     """
-    affiliations = list()
+    affiliations = []
     for author in variables["authors"]:
         _convert_field_to_list(
             dictionary=author,
@@ -147,7 +155,7 @@ def add_author_affiliations(variables: dict) -> dict:
         numbers = [affil_to_number[affil] for affil in author.get("affiliations", [])]
         author["affiliation_numbers"] = sorted(numbers)
     variables["affiliations"] = [
-        dict(affiliation=affil, affiliation_number=i)
+        {"affiliation": affil, "affiliation_number": i}
         for affil, i in affil_to_number.items()
     ]
     return variables

--- a/manubot/webpage/webpage_command.py
+++ b/manubot/webpage/webpage_command.py
@@ -173,7 +173,7 @@ def ots_upgrade(args):
     Upgrades each .ots file with a separate ots upgrade subprocess call due to
     https://github.com/opentimestamps/opentimestamps-client/issues/71
     """
-    ots_paths = list()
+    ots_paths = []
     for version in get_versions(args):
         ots_paths.extend(args.versions_directory.joinpath(version).glob("**/*.ots"))
     ots_paths.sort()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,24 @@ addopts = "--color=yes -rs"
 
 [tool.black]
 target-version = ['py37', 'py38', 'py39', 'py310', 'py311']
+line-length = 88
+
+[tool.ruff]
+target-version = "py37"
+ignore = [
+    "E501",  # line-too-long (black should handle)
+]
+line-length = 88
+select = [
+    "B",  # flake8-bugbear
+    "C",  # flake8-comprehensions
+    "C90",  # mccabe
+    "E",  # pycodestyle errors
+    "F",  # pyflakes
+    "I",  # isort
+    "UP",  # pyupgrade
+    "W",  # pycode warnings
+]
+
+[tool.ruff.mccabe]
+max-complexity = 19

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,18 +80,3 @@ manubot =
     cite/curie/*.json
     process/header-includes-template.html
     webpage/redirect-template.html
-
-[flake8]
-ignore = E203, E266, E501, F541, W503
-max-line-length = 80
-# TODO: refactor to reduce max-complexity to 18
-max-complexity = 19
-select = B,C,E,F,W,T4,B9
-
-[isort]
-profile = black
-multi_line_output = 3
-include_trailing_comma = True
-force_grid_wrap = 0
-use_parentheses = True
-line_length = 88


### PR DESCRIPTION
[Ruff](https://github.com/charliermarsh/ruff#pycodestyle-e-w) is an "extremely fast Python linter, written in Rust". It replaces several of our existing tools including flake8, pyupgrade, and isort. It uses the same error codes when possible. Has been gaining popularity recently with rave reviews, so giving it a try.