### PR TITLE
ai-revision: show a proper error when dependencies were not installed

### DIFF
--- a/manubot/ai_revision/ai_revision_command.py
+++ b/manubot/ai_revision/ai_revision_command.py
@@ -5,8 +5,13 @@ from pathlib import Path
 
 
 def cli_process(args):
-    from manubot_ai_editor import models
-    from manubot_ai_editor.editor import ManuscriptEditor
+    try:
+        from manubot_ai_editor import models
+        from manubot_ai_editor.editor import ManuscriptEditor
+    except ImportError as err:
+        raise ModuleNotFoundError(
+            "Install manubot with: pip install manubot[ai-rev]"
+        ) from err
 
     # set paths for content
     content_dir = args.content_directory


### PR DESCRIPTION
Show a proper message if dependencies for the `ai-revision` subcommand were not installed.

I'm not sure what's the best type of exception to thrown within `except`. I'm using `ModuleNotFoundError` now, which shows this message:

```bash
$ manubot ai-revision --content-directory ../rootstock/content/
Traceback (most recent call last):
  File "/home/miltondp/projects/others/manubot/manubot/manubot/ai_revision/ai_revision_command.py", line 9, in cli_process
    from manubot_ai_editor import models
ModuleNotFoundError: No module named 'manubot_ai_editor'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/miltondp/software/miniconda3/envs/manubot-dev/bin/manubot", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/miltondp/projects/others/manubot/manubot/manubot/command.py", line 302, in main
    function(args)
  File "/home/miltondp/projects/others/manubot/manubot/manubot/ai_revision/ai_revision_command.py", line 12, in cli_process
    raise ModuleNotFoundError(
ModuleNotFoundError: Install manubot with: pip install manubot[ai-rev]
```

which could be too much information. Another option is to log the error, suggest how to install manubot, and then run a `sys.exit(1)` (or whatever code is appropriate).