### PR TITLE
FIX: Test fails for no reason.

### DIFF
--- a/manubot/pandoc/tests/test_cite_filter/output.txt
+++ b/manubot/pandoc/tests/test_cite_filter/output.txt
@@ -32,7 +32,7 @@ Stephen F Altschul, Warren Gish, Webb Miller, Eugene W Myers, David J Lipman Jou
 DOI: 10.1016/s0022-2836(05)80360-2 · pmid: 2231712
 
 5. Semi-supervised Knowledge Transfer for Deep Learning from Private Training Data
-Nicolas Papernot, Martín Abadi, Úlfar Erlingsson, Ian Goodfellow, Kunal Talwar (2022-07-21) https://openreview.net/forum?id=HkwoSDPgg
+Nicolas Papernot, Martín Abadi, Úlfar Erlingsson, Ian Goodfellow, Kunal Talwar (2016-11-02) https://openreview.net/forum?id=HkwoSDPgg
 
 6. Open collaborative writing with Manubot
 Daniel S Himmelstein, Vincent Rubinetti, David R Slochower, Dongbo Hu, Venkat S Malladi, Casey S Greene, Anthony Gitter Manubot (2019-11-20) https://greenelab.github.io/meta-review/


### PR DESCRIPTION
manubot/pandoc/tests/test_cite_filter.py::test_cite_pandoc_filter fails on main.

The website [1] states in it's metadata that the article dates from 2016-11-02.

<meta name="citation_publication_date" content="2016/11/02"/>

Most likely, because that is the time for the first submission [2].

Having the test fails because it does not gives the date stated on the website does not good, as the tool is working as intended.

If someone cares about this date, either make a custom local citation or ask the admins of the website to update the metadata for the article.

[1]: https://openreview.net/forum?id=HkwoSDPgg
[2]: https://openreview.net/revisions?id=HkwoSDPgg