### PR TITLE
Fixes AI revision title, keyword propagation for models inheriting from GPT3CompletionModel

### DIFF
--- a/manubot/ai_revision/ai_revision_command.py
+++ b/manubot/ai_revision/ai_revision_command.py
@@ -32,7 +32,7 @@ def cli_process(args):
     # instantiate a model
     module_class = getattr(models, args.model_type)
 
-    if module_class == models.GPT3CompletionModel:
+    if issubclass(module_class, models.GPT3CompletionModel):
         model = module_class(
             title=me.title,
             keywords=me.keywords,


### PR DESCRIPTION
Currently, the implementation of `ai_revision_command.py` checks explicitly that a model is of type `GPT3CompletionModel` before providing the `title` and `keywords` arguments read from the manuscript's manifest. This excludes models that derive from `GPT3CompletionModel`, such as the [DebuggingManuscriptRevisionModel](https://github.com/falquaddoomi/manubot-ai-editor/blob/issue-31-customprompts-yaml/libs/manubot_ai_editor/models.py#L578).

This PR uses `issubclassof()` to change the explicit comparison against `GPT3CompletionModel` to comparing whether the model descends from `GPT3CompletionModel` (which `GPT3CompletionModel` itself satisfies).