### PR TITLE
ai-revision command: adds --config-directory argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ The `manubot ai-revision` command uses large language models from [OpenAI](https
 <!-- test codeblock contains output of `manubot ai-revision --help` -->
 ```
 usage: manubot ai-revision [-h] --content-directory CONTENT_DIRECTORY
+                           [--config-directory CONFIG_DIRECTORY]
                            [--model-type MODEL_TYPE]
                            [--model-kwargs key=value [key=value ...]]
                            [--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
@@ -321,6 +322,9 @@ options:
   -h, --help            show this help message and exit
   --content-directory CONTENT_DIRECTORY
                         Directory where manuscript content files are located.
+  --config-directory CONFIG_DIRECTORY
+                        Directory where AI revision configuration files are
+                        located. If unspecified, disables custom configuration.
   --model-type MODEL_TYPE
                         Model type used to revise the manuscript. Default is
                         GPT3CompletionModel. It can be any subclass of

--- a/manubot/ai_revision/ai_revision_command.py
+++ b/manubot/ai_revision/ai_revision_command.py
@@ -19,6 +19,14 @@ def cli_process(args):
         raise SystemExit(
             f"content directory is not a directory or does not exist: {content_dir}"
         )
+    
+    # set paths for config
+    # (the config directory is optional, but if it is provided, it must be a directory)
+    config_dir = args.config_directory
+    if config_dir is not None and not config_dir.is_dir():
+        raise SystemExit(
+            f"config directory is not a directory or does not exist: {config_dir}"
+        )
 
     # set paths for temporary output
     tmp_dir = Path(tempfile.mkdtemp(suffix="_manubot_ai_revision"))
@@ -27,6 +35,7 @@ def cli_process(args):
     # create a manuscript editor and model to revise
     me = ManuscriptEditor(
         content_dir=content_dir,
+        config_dir=config_dir,
     )
 
     # instantiate a model

--- a/manubot/ai_revision/ai_revision_command.py
+++ b/manubot/ai_revision/ai_revision_command.py
@@ -19,7 +19,7 @@ def cli_process(args):
         raise SystemExit(
             f"content directory is not a directory or does not exist: {content_dir}"
         )
-    
+
     # set paths for config
     # (the config directory is optional, but if it is provided, it must be a directory)
     config_dir = args.config_directory

--- a/manubot/command.py
+++ b/manubot/command.py
@@ -234,6 +234,13 @@ def add_subparser_airevision(subparsers):
         help="Directory where manuscript content files are located.",
     )
     parser.add_argument(
+        "--config-directory",
+        type=pathlib.Path,
+        required=False,
+        default=None,
+        help="Directory where AI revision configuration files are located. If unspecified, disables custom configuration.",
+    )
+    parser.add_argument(
         "--model-type",
         type=str,
         required=False,

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ dev =
     pytest >= 6.0.0
     yamllint
 ai-rev =
-    manubot-ai-editor >= 0.4.0
+    manubot-ai-editor >= 0.5.0
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
This PR adds an optional `--config-directory` argument to the `manubot ai-revision` CLI command. If specified, the directory will be searched for the optional files `ai-revision-config.yaml` and `ai-revision-prompts.yaml`, both of which are used to customize the AI revision system.

This PR relies on changes introduced in the not-yet-published `0.5.0` release of `manubot-ai-editor`, hence the version bump in `setup.cfg`. Reviewers should wait until that version is available before approving.