### PR TITLE
Add GitHub Actions Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# GitHub Dependabot configuration
+# Note: there is no interaction between this
+# configuration and dependabot security updates.
+# See here for more information:
+# https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates#about-dependabot-security-updates
+
+version: 2
+updates:
+  # GitHub Actions checks
+  # See here for more information:
+  # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every month
+      interval: "monthly"


### PR DESCRIPTION
This PR adds a GitHub actions Dependabot configuration which will automatically check and issue updates for actions used by the project. On merge, this will run for the first time, likely issuing PR's for stale actions which need an update.

References #379