### PR TITLE
Fixes for tests (part 2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,6 @@ jobs:
         - windows-latest
         - macOS-latest
         python-version:
-        - "3.8"
-        - "3.9"
         - "3.10"
         - "3.11"
         pandoc-version:

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,10 @@ Thumbs.db
 ## Text Editors
 .vscode
 .idea/
+
+venv
+
+manubot/cite/tests/cite-command-rendered/*.md
+manubot/cite/tests/cite-command-rendered/*.txt
+manubot/cite/tests/cite-command-rendered/*.xml
+manubot/cite/tests/cite-command-rendered/*.html

--- a/manubot/cite/arxiv.py
+++ b/manubot/cite/arxiv.py
@@ -2,9 +2,7 @@ import logging
 import re
 import xml.etree.ElementTree
 
-import requests
-
-from manubot.util import get_manubot_user_agent
+from manubot.util import get_manubot_user_agent, request_with_retry
 
 from .csl_item import CSL_Item
 from .handlers import Handler
@@ -78,7 +76,7 @@ def get_arxiv_csl_item(arxiv_id: str):
 
 def query_arxiv_api(url, params):
     headers = {"User-Agent": get_manubot_user_agent()}
-    response = requests.get(url, params, headers=headers)
+    response = request_with_retry(url, params=params, headers=headers, retries=1)
     response.raise_for_status()
     xml_tree = xml.etree.ElementTree.fromstring(response.text)
     return xml_tree

--- a/manubot/cite/arxiv.py
+++ b/manubot/cite/arxiv.py
@@ -76,7 +76,7 @@ def get_arxiv_csl_item(arxiv_id: str):
 
 def query_arxiv_api(url, params):
     headers = {"User-Agent": get_manubot_user_agent()}
-    response = request_with_retry(url, params=params, headers=headers, retries=1)
+    response = request_with_retry(url, params=params, headers=headers)
     response.raise_for_status()
     xml_tree = xml.etree.ElementTree.fromstring(response.text)
     return xml_tree

--- a/manubot/cite/pubmed.py
+++ b/manubot/cite/pubmed.py
@@ -289,7 +289,7 @@ def get_pmcid_and_pmid_for_doi(doi: str) -> Dict[str, str]:
     assert doi.startswith("10.")
     params = {"ids": doi, "tool": "manubot"}
     url = "https://www.ncbi.nlm.nih.gov/pmc/utils/idconv/v1.0/"
-    response = request_with_retry(url, params=params, retries=1)
+    response = request_with_retry(url, params=params)
     if not response.ok:
         logging.warning(f"Status code {response.status_code} querying {response.url}\n")
         return {}

--- a/manubot/cite/pubmed.py
+++ b/manubot/cite/pubmed.py
@@ -7,7 +7,7 @@ from xml.etree import ElementTree
 
 import requests
 
-from manubot.util import get_manubot_user_agent
+from manubot.util import get_manubot_user_agent, request_with_retry
 
 from .citekey import CiteKey
 from .handlers import Handler
@@ -289,7 +289,7 @@ def get_pmcid_and_pmid_for_doi(doi: str) -> Dict[str, str]:
     assert doi.startswith("10.")
     params = {"ids": doi, "tool": "manubot"}
     url = "https://www.ncbi.nlm.nih.gov/pmc/utils/idconv/v1.0/"
-    response = requests.get(url, params)
+    response = request_with_retry(url, params=params, retries=1)
     if not response.ok:
         logging.warning(f"Status code {response.status_code} querying {response.url}\n")
         return {}

--- a/manubot/cite/tests/test_zotero.py
+++ b/manubot/cite/tests/test_zotero.py
@@ -108,6 +108,7 @@ def test_search_query_isbn():
     """
     identifier = "isbn:9781339919881"
     zotero_data = search_query(identifier)
+    assert zotero_data
     assert zotero_data[0]["title"].startswith("The hetnet awakens")
 
 

--- a/manubot/cite/zotero.py
+++ b/manubot/cite/zotero.py
@@ -12,9 +12,9 @@ import logging
 from typing import Any, Dict, List
 
 import requests
+from requests.exceptions import JSONDecodeError as RequestsJSONDecodeError
 
 from manubot.util import get_manubot_user_agent, is_http_url, request_with_retry
-from requests.exceptions import JSONDecodeError as RequestsJSONDecodeError
 
 ZoteroRecord = Dict[str, Any]
 ZoteroData = List[ZoteroRecord]

--- a/manubot/cite/zotero.py
+++ b/manubot/cite/zotero.py
@@ -13,7 +13,8 @@ from typing import Any, Dict, List
 
 import requests
 
-from manubot.util import get_manubot_user_agent, is_http_url
+from manubot.util import get_manubot_user_agent, is_http_url, request_with_retry
+from requests.exceptions import JSONDecodeError as RequestsJSONDecodeError
 
 ZoteroRecord = Dict[str, Any]
 ZoteroData = List[ZoteroRecord]
@@ -33,14 +34,25 @@ def web_query(url: str) -> ZoteroData:
     headers = {"User-Agent": get_manubot_user_agent(), "Content-Type": "text/plain"}
     params = {"single": 1}
     api_url = f"{base_url}/web"
-    response = requests.post(api_url, params=params, headers=headers, data=str(url))
+    response = request_with_retry(
+        api_url, method="post", params=params, headers=headers, data=str(url)
+    )
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as error:
+        logging.warning(
+            f"web_query returned HTTP {response.status_code} for {url}:\n{response.text}"
+        )
+        raise error
     try:
         zotero_data = response.json()
-    except Exception as error:
+    except RequestsJSONDecodeError as error:
         logging.warning(
             f"Error parsing web_query output as JSON for {url}:\n{response.text}"
         )
-        raise error
+        raise requests.HTTPError(
+            f"Zotero web_query returned non-JSON response for {url}"
+        ) from error
     if response.status_code == 300:
         # When single=1 is specified, multiple results should never be returned
         logging.warning(
@@ -66,14 +78,25 @@ def search_query(identifier: str) -> ZoteroData:
     """
     api_url = f"{base_url}/search"
     headers = {"User-Agent": get_manubot_user_agent(), "Content-Type": "text/plain"}
-    response = requests.post(api_url, headers=headers, data=str(identifier))
+    response = request_with_retry(
+        api_url, method="post", headers=headers, data=str(identifier)
+    )
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as error:
+        logging.warning(
+            f"search_query returned HTTP {response.status_code} for {identifier}:\n{response.text}"
+        )
+        raise error
     try:
         zotero_data = response.json()
-    except Exception as error:
+    except RequestsJSONDecodeError as error:
         logging.warning(
             f"Error parsing search_query output as JSON for {identifier}:\n{response.text}"
         )
-        raise error
+        raise requests.HTTPError(
+            f"Zotero search_query returned non-JSON response for {identifier}"
+        ) from error
     zotero_data = _passthrough_zotero_data(zotero_data)
     return zotero_data
 

--- a/manubot/pandoc/tests/test_cite_filter.py
+++ b/manubot/pandoc/tests/test_cite_filter.py
@@ -61,4 +61,18 @@ def test_cite_pandoc_filter():
     print(shlex_join(process.args))
     print(process.stdout)
     print(process.stderr)
+    # check for execution errors we can skip
+    if process.returncode != 0:
+        stderr_lower = process.stderr.lower()
+        # if we're using incompatible architecture, skip the test
+        if "incompatible architecture" in stderr_lower:
+            pytest.skip(
+                "pandoc-manubot-cite is unavailable for this architecture:\n"
+                f"{process.stderr}"
+            )
+        # otherwise, fail the test
+        pytest.fail(
+            "pandoc-manubot-cite filter execution failed:\n"
+            f"{process.stderr}\n{process.stdout}"
+        )
     assert process.stdout.lower() == expected.lower()

--- a/manubot/util.py
+++ b/manubot/util.py
@@ -128,9 +128,9 @@ def request_with_retry(
     method: str = "get",
     params: typing.Optional[dict] = None,
     headers: typing.Optional[dict] = None,
-    retries: int = 5,
+    retries: int = 10,
     retry_statuses: typing.Tuple[int, ...] = (429,),
-    delay: float = 3.0,
+    delay: float = 10.0,
     **kwargs,
 ):
     """

--- a/manubot/util.py
+++ b/manubot/util.py
@@ -128,7 +128,7 @@ def request_with_retry(
     method: str = "get",
     params: typing.Optional[dict] = None,
     headers: typing.Optional[dict] = None,
-    retries: int = 10,
+    retries: int = 5,
     retry_statuses: typing.Tuple[int, ...] = (429, 503),
     backoff: float = 1.0,
     backoff_factor: float = 2.0,

--- a/manubot/util.py
+++ b/manubot/util.py
@@ -128,9 +128,9 @@ def request_with_retry(
     method: str = "get",
     params: typing.Optional[dict] = None,
     headers: typing.Optional[dict] = None,
-    retries: int = 2,
+    retries: int = 5,
     retry_statuses: typing.Tuple[int, ...] = (429,),
-    delay: float = 2.0,
+    delay: float = 3.0,
     **kwargs,
 ):
     """

--- a/manubot/util.py
+++ b/manubot/util.py
@@ -128,9 +128,9 @@ def request_with_retry(
     method: str = "get",
     params: typing.Optional[dict] = None,
     headers: typing.Optional[dict] = None,
-    retries: int = 1,
+    retries: int = 2,
     retry_statuses: typing.Tuple[int, ...] = (429,),
-    delay: float = 1.0,
+    delay: float = 2.0,
     **kwargs,
 ):
     """

--- a/manubot/util.py
+++ b/manubot/util.py
@@ -128,11 +128,11 @@ def request_with_retry(
     method: str = "get",
     params: typing.Optional[dict] = None,
     headers: typing.Optional[dict] = None,
-    retries: int = 3,
+    retries: int = 10,
     retry_statuses: typing.Tuple[int, ...] = (429, 503),
     backoff: float = 1.0,
     backoff_factor: float = 2.0,
-    max_backoff: float = 8.0,
+    max_backoff: float = 200.0,
     **kwargs,
 ):
     """


### PR DESCRIPTION
This PR seeks to fix tests within CI for this project (continuing from progress in #383).


Notes:
- I've removed Python 3.8 and 3.9 from tests - these are EoL ([link](https://devguide.python.org/versions/)).
- There are some cases where we see 429's from various API's. I've added in a simple utility function to help catch these and retry.
- There are a few cases where there appear to be race conditions for test files with the cite command. We resolve these by polling for the files so that the tests can run properly.