### PR TITLE
Add recent Python versions to tests matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
         python-version:
         - "3.10"
         - "3.11"
+        - "3.12"
+        - "3.13"
         pandoc-version:
         - "2.9.2"
         - "2.11.3.1"


### PR DESCRIPTION
This PR adds recent versions of Python to the tests matrix for CI, expanding the existing coverage. I opted to leave 3.14 out for now due to how new it is currently (and likelihood for challenges unrelated to the code here).